### PR TITLE
Add ASVS 4.0 mapping and correct the names on the cards and the name of the edition.

### DIFF
--- a/lib/copi/migrations/card_migration.ex
+++ b/lib/copi/migrations/card_migration.ex
@@ -59,16 +59,34 @@ defmodule Copi.CardMigration do
                   owasp_appsensor: set_mappings_for_card(card["owasp_appsensor"]),
                   capec: set_mappings_for_card(card["capec"]),
                   safecode: set_mappings_for_card(card["safecode"])
-                )
-                "masvs" -> Ecto.Changeset.change(this_card,
-                owasp_scp: [],
-                owasp_asvs: [],
-                owasp_masvs: set_mappings_for_card(card["owasp_masvs"]),
-                owasp_mastg: set_mappings_for_card(card["owasp_mastg"]),
-                owasp_appsensor: [],
-                capec: set_mappings_for_card(card["capec"]),
-                safecode: set_mappings_for_card(card["safecode"])
-                )
+              )
+              "webapp" -> Ecto.Changeset.change(this_card,
+                  owasp_scp: set_mappings_for_card(card["owasp_scp"]),
+                  owasp_asvs: set_mappings_for_card(card["owasp_asvs"]),
+                  owasp_masvs: [],
+                  owasp_mastg: [],
+                  owasp_appsensor: set_mappings_for_card(card["owasp_appsensor"]),
+                  capec: set_mappings_for_card(card["capec"]),
+                  safecode: set_mappings_for_card(card["safecode"])
+              )
+              "masvs" -> Ecto.Changeset.change(this_card,
+                  owasp_scp: [],
+                  owasp_asvs: [],
+                  owasp_masvs: set_mappings_for_card(card["owasp_masvs"]),
+                  owasp_mastg: set_mappings_for_card(card["owasp_mastg"]),
+                  owasp_appsensor: [],
+                  capec: set_mappings_for_card(card["capec"]),
+                  safecode: set_mappings_for_card(card["safecode"])
+              )
+              "mobileapp" -> Ecto.Changeset.change(this_card,
+                  owasp_scp: [],
+                  owasp_asvs: [],
+                  owasp_masvs: set_mappings_for_card(card["owasp_masvs"]),
+                  owasp_mastg: set_mappings_for_card(card["owasp_mastg"]),
+                  owasp_appsensor: [],
+                  capec: set_mappings_for_card(card["capec"]),
+                  safecode: set_mappings_for_card(card["safecode"])
+              )
             end
             Repo.update this_card
           end

--- a/lib/copi_web/controllers/card_html/show.html.heex
+++ b/lib/copi_web/controllers/card_html/show.html.heex
@@ -1,7 +1,7 @@
 <%= if @card do %>
 
   <%= cond do %>
-      <% @card.edition == "ecommerce" -> %>
+      <% @card.edition == "webapp" -> %>
 
     <div class={["card", @card.value, Slug.slugify @card.category]}>
       <div class="left-bar"><%= @card.category %></div>
@@ -80,7 +80,7 @@
       </div>
     </div>
 
-  <% @card.edition == "masvs" -> %>
+  <% @card.edition == "mobileapp" -> %>
 
       <div class={["card", @card.value, "#{Slug.slugify @card.category}-mobile"]}>
         <div class="left-bar"><%= @card.category %></div>

--- a/lib/copi_web/live/game_live/create_game_form.ex
+++ b/lib/copi_web/live/game_live/create_game_form.ex
@@ -27,8 +27,8 @@ defmodule CopiWeb.GameLive.CreateGameForm do
           type="select"
           label={gettext "Choose the type of game you wish to play"}
           options={[
-              {"Cornucopia Web (for web apps and APIs)", "ecommerce"},
-              {"Cornucopia Mobile (for mobile apps)", "masvs"},
+              {"Cornucopia Web (for web apps and APIs)", "webapp"},
+              {"Cornucopia Mobile (for mobile apps)", "mobileapp"},
               {"Elevation of Privilege (for cloud platforms, infrastructure, apps, anything!)", "eop"},
           ]}
           >

--- a/lib/copi_web/live/game_live/show.ex
+++ b/lib/copi_web/live/game_live/show.ex
@@ -119,8 +119,8 @@ defmodule CopiWeb.GameLive.Show do
 
   def display_game_session(edition) do
     case edition do
-      "ecommerce" -> "Cornucopia Web Session:"
-      "masvs" -> "Cornucopia Mobile Session:"
+      "webapp" -> "Cornucopia Web Session:"
+      "mobileapp" -> "Cornucopia Mobile Session:"
       _ -> "EoP Session:"
     end
   end

--- a/lib/copi_web/live/player_live/show.ex
+++ b/lib/copi_web/live/player_live/show.ex
@@ -146,8 +146,8 @@ defmodule CopiWeb.PlayerLive.Show do
 
   def display_game_session(edition) do
     case edition do
-      "ecommerce" -> "Cornucopia Web Session:"
-      "masvs" -> "Cornucopia Mobile Session:"
+      "webapp" -> "Cornucopia Web Session:"
+      "mobileapp" -> "Cornucopia Mobile Session:"
       _ -> "EoP Session:"
     end
   end

--- a/priv/repo/cornucopia/masvs-cards-1.00-en.yaml
+++ b/priv/repo/cornucopia/masvs-cards-1.00-en.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  edition: "masvs"
+  edition: "mobileapp"
   component: "cards"
   language: "EN"
   version: "1.00"

--- a/priv/repo/cornucopia/masvs-cards-1.00-en.yaml
+++ b/priv/repo/cornucopia/masvs-cards-1.00-en.yaml
@@ -1,6 +1,6 @@
 ---
 meta:
-  edition: "mobileapp"
+  edition: "masvs"
   component: "cards"
   language: "EN"
   version: "1.00"

--- a/priv/repo/cornucopia/mobileapp-cards-1.00-en.yaml
+++ b/priv/repo/cornucopia/mobileapp-cards-1.00-en.yaml
@@ -1,0 +1,806 @@
+---
+meta:
+  edition: "mobileapp"
+  component: "cards"
+  language: "EN"
+  version: "1.00"
+suits:
+-
+  name: "Platform & Code"
+  cards:
+  -
+    id: "PC2"
+    value: "2"
+    desc: "Andrew can expose sensitive data through the app's auto-generated screenshots when the app moves to the background"
+  -
+    id: "PC3"
+    value: "3"
+    desc: "Harold can spy sensitive data being entered through the user interface because the data is excessive, not properly masked or cleaned up after use"
+  -
+    id: "PC4"
+    value: "4"
+    desc: "Kelly can expose sensitive data by taking advantage of the app's excessive permissions connected to the app's use of location, camera, microphone, storage, etc"
+  -
+    id: "PC5"
+    value: "5"
+    desc: "Jason can provoke memory leak or corruption because the app has cyclic dependencies, manages pointers inadequately, keeps an incorrect reference count, does not release shared resources or apply stack protection"
+  -
+    id: "PC6"
+    value: "6"
+    desc: "Dawn can expose and intercept sensitive functionality through interprocess communication because permissions for broadcast and sharing are not set, not narrow enough or appropriately excluded when sharing"
+  -
+    id: "PC7"
+    value: "7"
+    desc: "Lauren can traverse or modify otherwise protected files through access to the underlying file system by exploiting weaknesses in file system-based content providers, resolvers or its configuration"
+  -
+    id: "PC8"
+    value: "8"
+    desc: "Colin can expose sensitive data through the app's interprocess communication because the content provider's query methods are not properly parameterized and arguments sanitized"
+  -
+    id: "PC9"
+    value: "9"
+    desc: "Toby can modify or expose data by injection because the response from implicit intents is not properly validated"
+  -
+    id: "PCX"
+    value: "10"
+    desc: "Max can modify or expose data because input validation and sanitation are not properly applied to interprocess communication or because extensions are not properly restricted"
+  -
+    id: "PCJ"
+    value: "J"
+    desc: "Johan can modify or expose sensitive data by exploiting weaknesses in the SDK or third party libraries because updates to the app and platform are not enforced or do not patch known software vulnerabilities"
+  -
+    id: "PCQ"
+    value: "Q"
+    desc: "Xavier can inject scripts into the web view because it allows embedding content using deep linking without proper authorization and validation of the host, schema and path of the target as these can be changed by the user or because safe browsing is disabled"
+  -
+    id: "PCK"
+    value: "K"
+    desc: "Grant can modify or expose data by influencing or altering JavaScript bridges, extensions or interprocess communication (e.g. shared memory, message passing, pipes, sockets)"
+  -
+    id: "PCA"
+    value: "A"
+    desc: "You have invented a new attack against “Platform and Code”"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App Code Quality” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Authentication & Authorization"
+  cards:
+  -
+    id: "AA2"
+    value: "2"
+    desc: "Jie can use the app to do sensitive operations because the “unlocked key” is not used during the application flow"
+  -
+    id: "AA3"
+    value: "3"
+    desc: "Choi can access capabilities, objects, resources, or properties they should not be authorized to access because entitlements or permissions are too wide, not properly set or not enforced"
+  -
+    id: "AA4"
+    value: "4"
+    desc: "Vandana can bypass biometric authentication because the authentication is misconfigured or not implemented correctly"
+  -
+    id: "AA5"
+    value: "5"
+    desc: "Eiman can bypass the local authentication through patching and/or by instrumentation because the authentication can be patched out or overloaded"
+  -
+    id: "AA6"
+    value: "6"
+    desc: "Anant can perform sensitive operations without additional authentication because authentication requirements are too weak or missing"
+  -
+    id: "AA7"
+    value: "7"
+    desc: "Abdullah can bypass authentication by altering the usual process sequence or flow, or by undertaking the process in incorrect order, or by manipulating date and time values used by the app, or by using valid features for unintended purposes"
+  -
+    id: "AA8"
+    value: "8"
+    desc: "Pramod can intercept credentials through misdirection because the app is vulnerable to attacks like Tapjacking, StrandHogg and/or URL scheme hijacking"
+  -
+    id: "AA9"
+    value: "9"
+    desc: "Wong can bypass the authentication because it does not fail securely. (i.e. it defaults to allowing unauthenticated access)"
+  -
+    id: "AAX"
+    value: "10"
+    desc: "Prasad can bypass the centralized authentication and authorization controls since they are not being used comprehensively on all interactions"
+  -
+    id: "AAJ"
+    value: "J"
+    desc: "Ade can bypass authentication because it is not enforced using a remote endpoint, or it is not based on a cryptographic primitive protected by keystore/keychain access control flags"
+  -
+    id: "AAQ"
+    value: "Q"
+    desc: "Riotaro can inject and run a command that the application will run at a higher privilege level without being authenticated or authorized to do so"
+  -
+    id: "AAK"
+    value: "K"
+    desc: "Aatif can influence or alter authentication controls and can therefore bypass them"
+  -
+    id: "AAA"
+    value: "A"
+    desc: "You have invented a new attack against “Authentication & Authorization”"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App Authentication Architectures” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Network & Storage"
+  cards:
+  -
+    id: "NS2"
+    value: "2"
+    desc: "Matt can inspect sensitive application log data because logging statements have not been removed or reviewed as safe before the production release"
+  -
+    id: "NS3"
+    value: "3"
+    desc: "Bil can access sensitive data for sensitive fields from the pasteboard/clipboard or keyboard cache because the pasteboard/clipboard is not timely cleared, disabled or restricted for sensitive fields, or the keyboard cache is not disabled"
+  -
+    id: "NS4"
+    value: "4"
+    desc: "Ricardo can extract data stored by the app on a stolen or decommissioned device  because it does not enforce device access security policies (e.g. PIN protected locking, app-/os-version, USB debug deactivation, device encryption and rooting)"
+  -
+    id: "NS5"
+    value: "5"
+    desc: "Kevin can read sensitive data mapped to user accounts or sessions by extracting data sent through third-party libraries and/or notifications sent between the app and embedded services (e.g. logs, notifications, backups, cache, local db)"
+  -
+    id: "NS6"
+    value: "6"
+    desc: "Sam can dump sensitive data from memory because the data is not stored as primitive data types and overwritten with random data after use or because the app's input fields use insecure SDKs to store the data in RAM"
+  -
+    id: "NS7"
+    value: "7"
+    desc: "Steve can access sensitive data by reading backups and/or local, internal/external storage"
+  -
+    id: "NS8"
+    value: "8"
+    desc: "Martin can modify or expose sensitive data through unsafe reflection when reading data from public data storage (e.g. shared preferences) because the data is not validated before being read by the app"
+  -
+    id: "NS9"
+    value: "9"
+    desc: "Adrian can compromise the app communication through a proxy because the app does not make use of certificate pinning or implements it incorrectly"
+  -
+    id: "NSX"
+    value: "10"
+    desc: "Maarten can compromise the communication between the app and the external services because the app does not verify TLS certificates and -chains, trust insecure sources, lack hostname verification or ignore TLS verification issues"
+  -
+    id: "NSJ"
+    value: "J"
+    desc: "Nihel can compromise the communication as it may fall back to an insecure or unencrypted channel,  because encryption is optional, or because of client-server protocol or security provider weaknesses"
+  -
+    id: "NSQ"
+    value: "Q"
+    desc: "Ahmed can read and modify data in transit because the communication is transmitted over an unencrypted channel"
+  -
+    id: "NSK"
+    value: "K"
+    desc: "Taher can intercept, extract or modify sensitive data at rest or in transit by influencing or altering methods for transferring or storing data at rest or in transit"
+  -
+    id: "NSA"
+    value: "A"
+    desc: "You have invented a new attack against “Network & Storage”"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App Network Communication” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Resilience"
+  cards:
+  -
+    id: "RS2"
+    value: "2"
+    desc: " Sebastien can disclose sensitive data because the application is set up to log debug information at runtime"
+  -
+    id: "RS3"
+    value: "3"
+    desc: "Tobias can disclose sensitive data by dumping debug symbols while the application is running"
+  -
+    id: "RS4"
+    value: "4"
+    desc: "Timur can change the code of the production release because the code of the application has not been properly signed using a valid production certificate"
+  -
+    id: "RS5"
+    value: "5"
+    desc: "Matteo can bypass access controls and trigger functionality because debugging is left enabled in the production build"
+  -
+    id: "RS6"
+    value: "6"
+    desc: "Joren can bypass access controls because the anti-debugging controls aren't strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RS7"
+    value: "7"
+    desc: "Erlend can compromise the app by running it in an emulator because the prevention against emulators are not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RS8"
+    value: "8"
+    desc: "Carlos can reverse engineer the app because the prevention against the use of anti reverse engineering tools are not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RS9"
+    value: "9"
+    desc: "Sean can reverse engineer the app because the code obfuscation is not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RSX"
+    value: "10"
+    desc: "Juan can bypass jailbreak and root detection and execute administrative functions to bypass integrity checks and access controls and trigger app functionality"
+  -
+    id: "RSJ"
+    value: "J"
+    desc: "Pekka can compromise the integrity of the storage because the file integrity checks are not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RSQ"
+    value: "Q"
+    desc: "Titus can patch out critical functionality because the runtime integrity checks are not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "RSK"
+    value: "K"
+    desc: "Sherif can influence or alter controls against reverse engineering and runtime protection and can therefore bypass them"
+  -
+    id: "RSA"
+    value: "A"
+    desc: "You have invented a new attack against Authorization"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App Tampering and Reverse Engineering” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Cryptography"
+  cards:
+  -
+    id: "CRM2"
+    value: "2"
+    desc: "Lesego can compromise cryptographic operations and resources because keys are reused for multiple purposes, or not used according to the purpose for which they were created"
+  -
+    id: "CRM3"
+    value: "3"
+    desc: "Emery can access data because it has been obfuscated rather than using an approved cryptographic function"
+  -
+    id: "CRM4"
+    value: "4"
+    desc: "Enselme can modify sensitive data (stored or in transit) because it is not subject to integrity checking"
+  -
+    id: "CRM5"
+    value: "5"
+    desc: "Orace can predict the seed value used for generating cryptographic keys thereby compromising the cryptographic key"
+  -
+    id: "CRM6"
+    value: "6"
+    desc: "Kouti can extract sensitive data because the cryptographic key, used, is hard-coded or stored insecurely such as in local, internal/external storage"
+  -
+    id: "CRM7"
+    value: "7"
+    desc: "Ramsey can access stored sensitive data because it is not securely encrypted"
+  -
+    id: "CRM8"
+    value: "8"
+    desc: "Adel can predict and use the app's cryptographic keys because they are insufficiently long and random, can be enumerated, or derived from known values"
+  -
+    id: "CRM9"
+    value: "9"
+    desc: "Fady can bypass cryptographic controls because they do not fail securely (i.e. they default to unprotected)"
+  -
+    id: "CRMX"
+    value: "10"
+    desc: "Ash can break the cryptography because it is not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "CRMJ"
+    value: "J"
+    desc: "Hassan can extract or modify sensitive data because functions for storage and/or encryption are weak, deprecated or used incorrectly"
+  -
+    id: "CRMQ"
+    value: "Q"
+    desc: "Simon can bypass hashing and encryption functions because they are custom and/or inadequately implemented"
+  -
+    id: "CRMK"
+    value: "K"
+    desc: "Tarik can influence or alter cryptographic operations and can therefore bypass them"
+  -
+    id: "CRMA"
+    value: "A"
+    desc: "You have invented a new attack against “Cryptography”"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App Cryptography” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Cornucopia"
+  cards:
+  -
+    id: "COM2"
+    value: "2"
+    desc: "Garth can reduce app users' privacy because the app is not transparent about the app's data collection and usage in a concise, easily accessible and understandable way"
+  -
+    id: "COM3"
+    value: "3"
+    desc: " Elsa can reduce app users' privacy because the app does not allow for the user to easily manage, delete and modify their data, change privacy settings and re-prompt for consent when more data is required"
+  -
+    id: "COM4"
+    value: "4"
+    desc: "Elizabeth can reduce app users' privacy because the app sends too much personal data without the user's consent to downstream services that are outside the user's control"
+  -
+    id: "COM5"
+    value: "5"
+    desc: "Debarghaya can reduce app users' privacy because the app repurpose personal information (e.g. device IDs, IP addresses, behavioral patterns) collected for security concerns in order to cater for commercial interests without consent"
+  -
+    id: "COM6"
+    value: "6"
+    desc: "Kim can reduce app users' privacy because the app repurpose biometric information (e.g. fingerprints, facial recognition data, etc.) collected for security concerns in order to cater for commercial interests"
+  -
+    id: "COM7"
+    value: "7"
+    desc: "Gastón can execute malicious actions through intent redirection because the intent is not properly sanitized and immutable"
+  -
+    id: "COM8"
+    value: "8"
+    desc: "Roxana can do arbitrary file overwrites and potentially execute malicious code through path traversal because the target path and directory is not appropriately validated"
+  -
+    id: "COM9"
+    value: "9"
+    desc: "Alessandro can exploit the app by taking advantage of buffer overflows and memory leaks to write foreign code within the mobile code's address space"
+  -
+    id: "COMX"
+    value: "10"
+    desc: "Carlos can use the application's notification services to launch phishing campaigns because notifications are not sanitized and validated according to best practices"
+  -
+    id: "COMJ"
+    value: "J"
+    desc: "Luis can influence or alter cryptographic methods to corrupt other users' data because the integrity of the encrypted data is not verified before being shared with external services"
+  -
+    id: "COMQ"
+    value: "Q"
+    desc: "Victor can patch the app and use it to distribute malicious code because the runtime integrity checks are not strong enough according to what is recommended or the perceived effort of a potential attacker"
+  -
+    id: "COMK"
+    value: "K"
+    desc: "Ruben can use the app, without modifications, to spread malicious code because methods for transfer and storage do not perform proper data sanitization and validation"
+  -
+    id: "COMA"
+    value: "A"
+    desc: "You have invented a new attack of any type"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Mobile Application Security, and “Mobile App User Privacy Protection” in the “Mobile Application Security Testing Guide” on the OWASP MAS website"
+-
+  name: "Wild Card"
+  cards:
+  -
+    id: "JOAM"
+    value: "JokerA"
+    card: "Joker"
+    desc: "Starr can influence, alter or affect the app so that it no longer complies with legal, regulatory, contractual or other mandates"
+    misc: "Have you thought about becoming an individual OWASP member? All tools, guidance and local meetings are free for everyone, but individual membership helps support OWASP's work"
+  -
+    id: "JOBM"
+    value: "JokerB"
+    card: "Joker"
+    desc: "Mallory can use the app installed on Bob's device maliciously to surveil, spy on, eavesdrop, control remotely, track or otherwise monitor Bob, without consent and/or notification"
+    misc: "Examine vulnerabilities and discover how they can be fixed using free MASTG reference applications on the OWASP MAS website"
+paragraphs:
+-
+  name: "Common"
+  sentences:
+  -
+    value: "NoCard"
+    text: "No Card"
+  -
+    value: "Title"
+    text: "Mobile App Edition v1.00-EN"
+  -
+    value: "Title_full"
+    text: "OWASP® Cornucopia Mobile App Edition v1.00-EN"
+  -
+    value: "T00010"
+    text: "OWASP® Cornucopia is a mechanism to assist software development teams identify security requirements in Agile, conventional and formal development processes."
+  -
+    value: "T00020"
+    text: "Authors"
+  -
+    value: "T00100"
+    text: "Acknowledgements"
+  -
+    value: "T00110"
+    text: "Adam Shostack and the Microsoft SDL Team for the “Elevation of Privilege Threat Modelling Game”, published under a Creative Commons Attribution license, as the inspiration for Cornucopia and from which many ideas, especially the game theory, were copied."
+  -
+    value: "T00120"
+    text: "Colin Watson for coming up with Cornucopia which OWASP Cornucopia Mobile App Edition is based on."
+  -
+    value: "T00130"
+    text: "Contributors, supporters, sponsors and volunteers to the OWASP MASVS/MASTG, Mitre's Common Attack Pattern Enumeration and Classification (CAPEC), and SAFECode's “Practical Security Stories and Security Tasks for Agile Development Environments” which are all used in the cross-references provided."
+  -
+    value: "T00145"
+    text: "Current and past OWASP® Cornucopia project contributors and leaders, especially those involved most recently updating the cross-references, creating online versions, and writing scripts to dynamically generate Cornucopia's output files."
+  -
+    value: "T00150"
+    text: "Blackfoot (UK) Limited for creating and donating print-ready design files, Tom Brennan and the OWASP® Foundation for instigating the creation of an OWASP-branded box and leaflet, and Secure Delivery Ltd for developing and donating Copi, the platform to play Cornucopia and EoP online."
+  -
+    value: "T00161"
+    text: "(continued on page 20)"
+  -
+    value: "T00162"
+    text: "(continued from page 10)"
+  -
+    value: "T00200"
+    text: "Introduction"
+  -
+    value: "T00210"
+    text: "The idea behind Cornucopia is to help development teams, especially those using Agile methodologies, to identify application security requirements and develop security-based user stories."
+  -
+    value: "T00220"
+    text: "Cornucopia Mobile App Edition uses the same concepts and game strategy as the Cornucopia Website App Edition, but are made for developement team doing mobile development. Cornucopia is inspired by “Elevation of Privilege: The Threat Modeling Game (EoP)”."
+  -
+    value: "T00240"
+    text: "Cornucopia attempts to introduce threat-modelling ideas into mobile development teams that use Agile methodologies, or are more focused on mobile application weaknesses than other types of software vulnerabilities."
+  -
+    value: "T00300"
+    text: "The card deck (pack)"
+  -
+    value: "T00310"
+    text: "The card scenarios are meant to cover all the MASVS 2.0 requirements, all the tests from the MASTG and any additional guidelines from the Android and IOS secure coding guides. This was done in order to allow the game to be as aligned as possible with the latest guidelines for secure mobile development. Still, it's important to keep in mind that security guidelines and requirements are always in motion and that the game first of all should be used as a support when doing mobile application threat modeling and not as a complete guide into security requirements and guidelines."
+  -
+    value: "T00311"
+    text: "Cornucopia Mobile App Edition suits are based on the sections in the Mobile Application Security Verification Standard."
+  -
+    value: "T00320"
+    text: "These provided five suits, and a sixth called “Cornucopia” was created as a trump suite: "
+  -
+    value: "T00330"
+    text: "Platform & Code (PC)"
+  -
+    value: "T00340"
+    text: "Authentication & Authorization (AA)"
+  -
+    value: "T00350"
+    text: "Network & Storage (NS)"
+  -
+    value: "T00360"
+    text: "Resilience (RS)"
+  -
+    value: "T00370"
+    text: "Cryptography (CRM)"
+  -
+    value: "T00380"
+    text: "Cornucopia (COM)"
+  -
+    value: "T00390"
+    text: "Smilar to poker-playing cards, each suit contains 13 cards (Ace, 2-10, Jack, Queen and King)."
+  -
+    value: "T00400"
+    text: "There are also two Joker cards similar to the Cornucopia Website App Edition."
+  -
+    value: "T00500"
+    text: "Mappings"
+  -
+    value: "T00510"
+    text: "The other driver for Mobile Cornucopia is to link the attacks with requirements and verification techniques."
+  -
+    value: "T00520"
+    text: "In addition to having the MASVS 2.0 requirement codes and MASTG test codes printed on them, the cards also links to CAPEC software attack pattern IDs which themselves are mapped to CWEs."
+  -
+    value: "T00530"
+    text: "Each card is also mapped to the 36 primary security stories in the SAFECode document to help teams create their own security-related stories for use in Agile processes."
+  -
+    value: "T00600"
+    text: "Game strategy"
+  -
+    value: "T00610"
+    text: "Apart from the content differences, the game rules are virtually identical to those for the Corncuopia Website App Edition."
+  -
+    value: "T01000"
+    text: "Provide feedback"
+  -
+    value: "T01010"
+    text: "If you have ideas or feedback on the use of OWASP® Mobile Cornucopia, please share them."
+  -
+    value: "T01020"
+    text: "Even better if you create alternative versions of the cards, or produce professional print-ready versions, please share that with the volunteers who created this edition and with the wider application development and application security community."
+  -
+    value: "T01030"
+    text: "The best place to use to discuss or contribute is the list/group for the OWASP project:"
+  -
+    value: "T01040"
+    text: "List/Group"
+  -
+    value: "T01050"
+    text: "Project home page"
+  -
+    value: "T01060"
+    text: "All OWASP documents and tools are free to download and use."
+  -
+    value: "T01070"
+    text: "OWASP® Mobile Cornucopia is licensed under the Creative Commons Attribution-ShareAlike 3.0 license."
+  -
+    value: "T01100"
+    text: "Instructions"
+  -
+    value: "T01110"
+    text: "The text on each card describes an attack, but the attacker is given a name, which are unique across all the cards."
+  -
+    value: "T01120"
+    text: "The name can represent a computer system (e.g. the database, the file system, another application, a related service, a botnet), an individual person (e.g. a citizen, a customer, a client, an employee, a criminal, a spy), or even a group of people (e.g. a competitive organization, activists with a common cause)."
+  -
+    value: "T01130"
+    text: "The attacker might be remote in some other device/location, or local/internal with access to the same device, host or network as the application is running on."
+  -
+    value: "T01140"
+    text: "The attacker is always named at the start of each description"
+  -
+    value: "T01150"
+    text: "An example is:"
+  -
+    value: "T01160"
+    text: "Wong can bypass the authentication because it does not fail securely."
+  -
+    value: "T01170"
+    text: "This means the attacker, Wong, can log into the app without providing credentials because the login mechanism allows access when it fails."
+  -
+    value: "T01180"
+    text: "The attacks were primarily drawn from the MASVS 2.0 Mobile Application Testing guide and the Android and IOS secure coding guides"
+  -
+    value: "T01200"
+    text: "Lookups between the attacks and the guides are provided on most cards:"
+  -
+    value: "T01210"
+    text: "Test codes from the MASVS Mobile application Test Guide:"
+  -
+    value: "T01220"
+    text: "Verification IDs in “Mobile Application Security Verification Standard (MASVS) 2.0 for Mobile Applications”"
+  -
+    value: "T01240"
+    text: "IDs in “Common Attack Pattern Enumeration and Classification (CAPEC)”, v2.8, Mitre Corporation, November 2015"
+  -
+    value: "T01250"
+    text: "Security-focused stories in 'Practical Security Stories and Security Tasks for Agile Development Environments', SAFECode, July 2012"
+  -
+    value: "T01260"
+    text: "A look-up means the attack is included within the referenced item, but does not necessarily encompass the whole of its intent. "
+  -
+    value: "T01270"
+    text: "For structured data like CAPEC, the most specific reference is provided but sometimes a cross-reference is provided that also has more specific (child) examples."
+  -
+    value: "T01280"
+    text: "There are no lookups on the six Aces and two Jokers. "
+  -
+    value: "T01290"
+    text: "Instead these cards have some general tips in italicized text."
+  -
+    value: "T01300"
+    text: "It is possible to play Cornucopia in many different ways. "
+  -
+    value: "T01301"
+    text: "For how to play, continue on pages: 11-19."
+  -
+    value: "T01400"
+    text: "Preparations"
+  -
+    value: "T01410"
+    text: "Obtain a deck, or print your own deck of Cornucopia cards (see page 2 of this document) and separate/cut out the cards"
+  -
+    value: "T01411"
+    text: "Use the cards in this pack"
+  -
+    value: "T01420"
+    text: "Identify an application or application process to review; this might be a concept, design or an actual implementation"
+  -
+    value: "T01430"
+    text: "Create a data flow diagram, user stories, or other artefacts to help the review"
+  -
+    value: "T01440"
+    text: "Identify and invite a group of 3-6 architects, developers, testers and other business stakeholders together and sit around a table (try to include someone fairly familiar with application security)"
+  -
+    value: "T01450"
+    text: "Have some prizes to hand (gold stars, chocolate, pizza, beer or flowers depending upon your office culture)"
+  -
+    value: "T01500"
+    text: "Play"
+  -
+    value: "T01510"
+    text: "One suit - Cornucopia - acts as trumps."
+  -
+    value: "T01520"
+    text: "Aces are high (i.e. they beat Kings)."
+  -
+    value: "T01530"
+    text: "It helps if there is a non-player to document the issues and scores."
+  -
+    value: "T01540"
+    text: "Remove the Jokers and a few low-score (2, 3, 4) cards from Cornucopia suit to ensure each player will have the same number of cards"
+  -
+    value: "T01550"
+    text: "Shuffle the deck and deal all the cards"
+  -
+    value: "T01560"
+    text: "To begin, choose a player randomly who will play the first card - they can play any card from their hand except from the trump suit - Cornucopia"
+  -
+    value: "T01570"
+    text: "To play a card, each player must read it out aloud, and explain (see the online Wiki Deck for tips) how the threat could apply (the player gets a point for attacks that might work which the group thinks is an actionable bug) - do not try to think of mitigations at this stage, and do not exclude a threat just because of a belief that it is already mitigated - someone note the card and record the issues raised"
+  -
+    value: "T01580"
+    text: "Play clockwise, each person must play a card in the same way; if you have any card of the matching lead suit you must play one of those, otherwise they can play a card from any other suit. "
+  -
+    value: "T01590"
+    text: "Only a higher card of the same suit, or the highest card in the trump suit Cornucopia, wins the hand."
+  -
+    value: "T01600"
+    text: "The person who wins the round, leads the next round (i.e. they play first), and thus defines the next lead suit"
+  -
+    value: "T01610"
+    text: "Repeat until all the cards are played"
+  -
+    value: "T01700"
+    text: "Scoring"
+  -
+    value: "T01710"
+    text: "The objective is to identify applicable threats, and win hands (rounds):"
+  -
+    value: "T01720"
+    text: "Score +1 for each card you can identify as a valid threat to the application under consideration"
+  -
+    value: "T01730"
+    text: "Score +1 if you win a round"
+  -
+    value: "T01740"
+    text: "Once all cards have been played, whoever has the most points wins"
+  -
+    value: "T01800"
+    text: "Closure"
+  -
+    value: "T01810"
+    text: "Review all the applicable threats and the matching security requirements"
+  -
+    value: "T01820"
+    text: "Create user stories, specifications and test cases as required for your development methodology."
+  -
+    value: "T01900"
+    text: "Alternative game rules"
+  -
+    value: "T01910"
+    text: "If you are new to the game, remove the Aces and two Joker cards to begin with."
+  -
+    value: "T01920"
+    text: "Add the Joker cards back in once people become more familiar with the process."
+  -
+    value: "T01930"
+    text: "Apart from the “trumps card game” rules described above which are very similar to the EoP, the deck can also be played as the “twenty-one card game” (also known as “pontoon” or “blackjack”) which normally reduces the number of cards played in each round."
+  -
+    value: "T01940"
+    text: "Practice on an imaginary application, or even a future planned application, rather than trying to find fault with existing applications until the participants are happy with the usefulness of the game."
+  -
+    value: "T01950"
+    text: "Consider just playing with one suit to make a shorter session - but try to cover all the suits for every project. "
+  -
+    value: "T01960"
+    text: "Or even better just play one hand with some pre-selected cards, and score only on the ability to identify security requirements. "
+  -
+    value: "T01970"
+    text: "Perhaps have one game of each suit each day for a week or so, if the participants cannot spare long enough for a full deck."
+  -
+    value: "T01980"
+    text: "Some teams have preferred to play a full hand of cards, and then discuss what is on the cards after each round (instead of after each person plays a card)."
+  -
+    value: "T01990"
+    text: "Another suggestion is that if a player fails to identify the card is relevant, allow other players to suggest ideas, and potentially let them gain the point for the card. "
+  -
+    value: "T02000"
+    text: "Consider allowing extra points for especially good contributions."
+  -
+    value: "T02010"
+    text: "You can even play by yourself. "
+  -
+    value: "T02020"
+    text: "Just use the cards to act as thought-provokers. "
+  -
+    value: "T02030"
+    text: "Involving more people will be beneficial though."
+  -
+    value: "T02040"
+    text: "In Microsoft's EoP guidance, they recommend cheating as a good game strategy."
+  -
+    value: "T02600"
+    text: "Frequently asked questions"
+  -
+    value: "T02610"
+    text: "1. Can I copy or edit the game?"
+  -
+    value: "T02620"
+    text: "Yes of course."
+  -
+    value: "T02630"
+    text: "All OWASP materials are free to do with as you like provided you comply with the Creative Commons Attribution-ShareAlike 3.0 license. "
+  -
+    value: "T02640"
+    text: "Perhaps if you create a new version, you might donate it to the OWASP® Cornucopia Project?"
+  -
+    value: "T02650"
+    text: "2. How can I get involved?"
+  -
+    value: "T02660"
+    text: "Please send ideas or offers of help to the project's mailing list."
+  -
+    value: "T02670"
+    text: "3. How were the attackers' names chosen?"
+  -
+    value: "T02680"
+    text: "EoP begins every description with words like 'An attacker can...',"
+  -
+    value: "T02690"
+    text: "but Colin Watson used personal names in Cornucopia which can be thought of as external or internal people or aliases for computer systems."
+  -
+    value: "T02700"
+    text: "Likewise, the Mobile App Edition names reflect the OWASP community aspect."
+  -
+    value: "T02710"
+    text: "Therefore, apart from 'Bob and Mallory', the attacker names are drawn from the 2024 OWASP Global and EU board members, OWASP Staff, OWASP Cornucopia Mobile App Edition authors and contributors, and OWASP Chapter leaders around the world."
+  -
+    value: "T02720"
+    text: "The cultural and gender mix simply reflects these sources of names"
+  -
+    value: "T02730"
+    text: ", and is not meant to be world-representative."
+  -
+    value: "T02750"
+    text: "4. Why aren't there any images on the card faces?"
+  -
+    value: "T02760"
+    text: "There is quite a lot of text on the cards, and the cross-referencing takes up space too."
+  -
+    value: "T02770"
+    text: "But it would be great to have additional design elements included."
+  -
+    value: "T02780"
+    text: "Any volunteers"
+  -
+    value: "T02790"
+    text: "5. Are the attacks ranked by the number on the card?"
+  -
+    value: "T02800"
+    text: "Only approximately."
+  -
+    value: "T02810"
+    text: "The risk will be application and organisation dependent, due to varying security and compliance requirements, so your own severity rating may place the cards in some other order than the numbers on the cards."
+  -
+    value: "T02820"
+    text: "6. How long does it take to play a round of cards using the full deck?"
+  -
+    value: "T02830"
+    text: "This depends upon the scope of the application, amount of discussion and how familiar the players are with application security concepts."
+  -
+    value: "T02840"
+    text: "But perhaps allow 1.5 to 2.0 hours for 4-6 people."
+  -
+    value: "T02850"
+    text: "7. What sort of people should play the game?"
+  -
+    value: "T02860"
+    text: "Always try to have a mix of roles who can contribute alternative perspectives."
+  -
+    value: "T02870"
+    text: "But include someone who has a reasonable knowledge of application vulnerability terminology. "
+  -
+    value: "T02880"
+    text: "Otherwise try to include a mix of architects, developers, testers and a relevant project manager or business owner."
+  -
+    value: "T02890"
+    text: "8. Who should take notes and record scores?"
+  -
+    value: "T02900"
+    text: "It is better if that someone else, not playing the game, takes notes about the requirements identified and issues discussed."
+  -
+    value: "T02910"
+    text: "This could be used as training for a more junior developer, or performed by the project manager."
+  -
+    value: "T02920"
+    text: "Some organisations have made a recording to review afterwards when the requirements are written up more formally."
+  -
+    value: "T02930"
+    text: "9. Should we always use the full deck of cards?"
+  -
+    value: "T02940"
+    text: "No. "
+  -
+    value: "T02950"
+    text: "A smaller deck is quicker to play. "
+  -
+    value: "T02960"
+    text: "Start your first game with only enough cards for two or three rounds. "
+  -
+    value: "T02970"
+    text: "Always consider removing cards that are not appropriate at all of the target application or function being reviewed. "
+  -
+    value: "T02980"
+    text: "For the first few times people play the game it is also usually better to remove the Aces and the two Jokers."
+  -
+    value: "T02990"
+    text: "It is also usual to play the game without any trumps suit until people are more familiar with the idea."
+  -
+    value: "T03000"
+    text: "10. What should players do when they have an Ace card that says “invented a new X attack”?"
+  -
+    value: "T03010"
+    text: "The player can make up any attack they think is valid, but must match the suit of the card (e.g. Platform & Code)."
+  -
+    value: "T03020"
+    text: "With players new to the game, it can be better to remove these to begin with (see also FAQ 9)."
+  -
+    value: "T03850"
+    text: "OWASP's hard-working employees."

--- a/priv/repo/cornucopia/mobileapp-mappings-1.00.yaml
+++ b/priv/repo/cornucopia/mobileapp-mappings-1.00.yaml
@@ -1,0 +1,532 @@
+---
+meta:
+  edition: "mobileapp"
+  component: "mappings"
+  language: "ALL"
+  version: "1.0"
+  layouts: ["cards", "leaflet"]
+  templates: ["bridge_qr", "bridge", "tarot"]
+  languages: ["en"]
+suits:
+-
+  name: "Platform & Code"
+  cards:
+  -
+    id: "PC2"
+    value: "2"
+    owasp_masvs: [ PLATFORM-3 ]
+    owasp_mastg: [ TEST-0010, TEST-0059 ]
+    capec: [ 37, 155, 498, 648 ]
+    safecode: [ "-" ]
+  -
+    id: "PC3"
+    value: "3"
+    owasp_masvs: [ PLATFORM-3 ]
+    owasp_mastg: [ TEST-0008, TEST-0037, TEST-0057 ]
+    capec: [ 508 ]
+    safecode: [ "-" ]
+  -
+    id: "PC4"
+    value: "4"
+    owasp_masvs: [ PLATFORM-1 ]
+    owasp_mastg: [ TEST-0024, TEST-0069 ]
+    capec: [ 634, 651 ]
+    safecode: [ 11 ]
+  -
+    id: "PC5"
+    value: "5"
+    owasp_masvs: [ CODE-4 ]
+    owasp_mastg: [ TEST-0043, TEST-0044, TEST-0086 ]
+    capec: [ 14, 24, 44, 45, 46, 47, 92, 100, 124, 128, 129, 131, 679 ]
+    safecode: [ 7, 9, 34, 36 ]
+  -
+    id: "PC6"
+    value: "6"
+    owasp_masvs: [ PLATFORM-1 ]
+    owasp_mastg: [ TEST-0029, TEST-0030,  TEST-0071 ]
+    capec: [ 94,117, 499, 502, 504 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "PC7"
+    value: "7"
+    owasp_masvs: [ PLATFORM-1 ]
+    owasp_mastg: [ TEST-0007, TEST-0056 ]
+    capec: [ 126, 127, 139, 597, 643 ]
+    safecode: [ 16, 33 ]
+  -
+    id: "PC8"
+    value: "8"
+    owasp_masvs: [ PLATFORM-1 ]
+    owasp_mastg: [ TEST-0007, TEST-0056 ]
+    capec: [ 137, 499, 502, 586 ]
+    safecode: [ "-" ]
+  -
+    id: "PC9"
+    value: "9"
+    owasp_masvs: [ CODE-4 ]
+    owasp_mastg: [ TEST-0026 ]
+    capec: [ 497, 499, 502 ]
+    safecode: [ 17 ]
+  -
+    id: "PCX"
+    value: "10"
+    owasp_masvs: [ CODE-4 ]
+    owasp_mastg: [ TEST-0025, TEST-0072 ]
+    capec: [ 137, 499, 502, 586 ]
+    safecode: [ "-" ]
+  -
+    id: "PCJ"
+    value: "J"
+    owasp_masvs: [ CODE-1, CODE-2, CODE-3 ]
+    owasp_mastg: [ TEST-0036, TEST-0042, TEST-0080, TEST-0085 ]
+    capec: [ 310, 538, 691 ]
+    safecode: [ "-" ]
+  -
+    id: "PCQ"
+    value: "Q"
+    owasp_masvs: [ PLATFORM-1, PLATFORM-2 ]
+    owasp_mastg: [ TEST-0027, TEST-0028, TEST-0031, TEST-0070, TEST-0076, TEST-0077 ]
+    capec: [ 175, 240, 242, 500, 591, 592 ]
+    safecode: [ 17 ]
+  -
+    id: "PCK"
+    value: "K"
+    owasp_masvs: [ PLATFORM-1, PLATFORM-2 ]
+    owasp_mastg: [ TEST-0007, TEST-0030, TEST-0033, TEST-0056, TEST-0072, TEST-0078 ]
+    capec: [ 137, 138, 499, 502, 586 ]
+    safecode: [ "-" ]
+-
+  name: "Authentication & Authorization"
+  cards:
+  -
+    id: "AA2"
+    value: "2"
+    owasp_masvs: [ AUTH-2,  AUTH-3 ]
+    owasp_mastg: [ TEST-0017, TEST-0064 ]
+    capec: [ 115 ]
+    safecode: [ 28 ]
+  -
+    id: "AA3"
+    value: "3"
+    owasp_masvs: [ AUTH-1, AUTH-3 ]
+    owasp_mastg: [ TEST-0024, TEST-0032, TEST-0069, TEST-0077 ]
+    capec: [ 122 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AA4"
+    value: "4"
+    owasp_masvs: [ AUTH-2 ]
+    owasp_mastg: [ TEST-0018 ]
+    capec: [ 114, 115, 554 ]
+    safecode: [ 28 ]
+  -
+    id: "AA5"
+    value: "5"
+    owasp_masvs: [ AUTH-2 ]
+    owasp_mastg: [ TEST-0017, TEST-0018,  TEST-0064 ]
+    capec: [ 114, 115, 207, 554 ]
+    safecode: [ 28 ]
+  -
+    id: "AA6"
+    value: "6"
+    owasp_masvs: [  AUTH-2, AUTH-3 ]
+    owasp_mastg: [ TEST-0064 ]
+    capec: [ 20, 49, 50, 55, 115 ]
+    safecode: [ 28 ]
+  -
+    id: "AA7"
+    value: "7"
+    owasp_masvs: [ AUTH-1 ]
+    owasp_mastg: [ TEST-0034, TEST-0079 ]
+    capec: [ 39, 74, 162, 166, 207 ]
+    safecode: [ 8, 10, 11, 12 ]
+  -
+    id: "AA8"
+    value: "8"
+    owasp_masvs: [ AUTH-1, CODE-4, PLATFORM-1, PLATFORM-3 ]
+    owasp_mastg: [ TEST-0025, TEST-0030, TEST-0035, TEST-0072, TEST-0075 ]
+    capec: [ 153, 505, 506 ]
+    safecode: [  ]
+  -
+    id: "AA9"
+    value: "9"
+    owasp_masvs: [ AUTH-2 ]
+    owasp_mastg: [ TEST-0017, TEST-0018,  TEST-0064 ]
+    capec: [ 114, 115, 554 ]
+    safecode: [ 28 ]
+  -
+    id: "AAX"
+    value: "10"
+    owasp_masvs: [ AUTH-1 ]
+    owasp_mastg: [ TEST-0017, TEST-0064 ]
+    capec: [ 36, 121 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AAJ"
+    value: "J"
+    owasp_masvs: [ AUTH-2 ]
+    owasp_mastg: [ TEST-0017, TEST-0018,  TEST-0064 ]
+    capec: [ 114, 115, 554 ]
+    safecode: [ 28 ]
+  -
+    id: "AAQ"
+    value: "Q"
+    owasp_masvs: [ AUTH-1 ]
+    owasp_mastg: [ TEST-0033, TEST-0025,  TEST-0078 ]
+    capec: [ 17, 30, 69, 234 ]
+    safecode: [ 8, 10,11 ]
+  -
+    id: "AAK"
+    value: "K"
+    owasp_masvs: [ AUTH-2 ]
+    owasp_mastg: [ TEST-0017, TEST-0018,  TEST-0064 ]
+    capec: [ 114, 115, 207, 554 ]
+    safecode: [ 8, 10, 11 ]
+-
+  name: "Network & Storage"
+  cards:
+  -
+    id: "NS2"
+    value: "2"
+    owasp_masvs: [ STORAGE-2 ]
+    owasp_mastg: [ TEST-0003, TEST-0053 ]
+    capec: [ 155 ]
+    safecode: [ 11, 23, 29 ]
+  -
+    id: "NS3"
+    value: "3"
+    owasp_masvs: [ STORAGE-2 ]
+    owasp_mastg: [ TEST-0006, TEST-0055, TEST-0073 ]
+    capec: [ 204, 637, 679 ]
+    safecode: [ "-" ]
+  -
+    id: "NS4"
+    value: "4"
+    owasp_masvs: [ STORAGE-1 ]
+    owasp_mastg: [ TEST-0012 ]
+    capec: [ 406, 675 ]
+    safecode: [ "-" ]
+  -
+    id: "NS5"
+    value: "5"
+    owasp_masvs: [ STORAGE-2 ]
+    owasp_mastg: [ TEST-0004, TEST-0005, TEST-0054 ]
+    capec: [ 155, 161,  204, 220,  639, 643 ]
+    safecode: [ 11, 23, 29 ]
+  -
+    id: "NS6"
+    value: "6"
+    owasp_masvs: [ STORAGE-2 ]
+    owasp_mastg: [ TEST-0011, TEST-0060 ]
+    capec: [ 679 ]
+    safecode: [ "-" ]
+  -
+    id: "NS7"
+    value: "7"
+    owasp_masvs: [ STORAGE-1, STORAGE-2 ]
+    owasp_mastg: [ TEST-0001, TEST-0003, TEST-0009,  TEST-0052, TEST-0053, TEST-0058 ]
+    capec: [ 37, 155, 204, 639, 643 ]
+    safecode: [ 11, 23, 29 ]
+  -
+    id: "NS8"
+    value: "8"
+    owasp_masvs: [ STORAGE-1, CODE-4 ]
+    owasp_mastg: [ TEST-0002 ]
+    capec: [ 176 ]
+    safecode: [ "-" ]
+  -
+    id: "NS9"
+    value: "9"
+    owasp_masvs: [ NETWORK-2 ]
+    owasp_mastg: [ TEST-0022, TEST-0068 ]
+    capec: [ 57, 94, 156, 465, 466, 479, 701 ]
+    safecode: [ 14, 30 ]
+  -
+    id: "NSX"
+    value: "10"
+    owasp_masvs: [ NETWORK-1 ]
+    owasp_mastg: [ TEST-0019, TEST-0021, TEST-0065, TEST-0067 ]
+    capec: [ 57, 94, 156, 465, 466, 479, 701 ]
+    safecode: [ 14, 29, 30 ]
+  -
+    id: "NSJ"
+    value: "J"
+    owasp_masvs: [ NETWORK-1 ]
+    owasp_mastg: [ TEST-0020, TEST-0023, TEST-0066 ]
+    capec: [ 57, 94, 156, 220, 459, 465, 466 ]
+    safecode: [ 12, 14, 29, 30 ]
+  -
+    id: "NSQ"
+    value: "Q"
+    owasp_masvs: [ NETWORK-1 ]
+    owasp_mastg: [ TEST-0019, TEST-0065 ]
+    capec: [ 31, 36, 57, 102, 157, 158, 384, 466 ]
+    safecode: [ 29, 30 ]
+  -
+    id: "NSK"
+    value: "K"
+    owasp_masvs: [ STORAGE-1 ]
+    owasp_mastg: [ TEST-0001, TEST-0052 ]
+    capec: [ 75, 76, 113, 153, 161, 165, 176, 190, 207, 210, 554, 562 ]
+    safecode: [ 12, 19 ]
+-
+  name: "Resilience"
+  cards:
+  -
+    id: "RS2"
+    value: "2"
+    owasp_masvs: [ RESILIENCE-3 ]
+    owasp_mastg: [ TEST-0041, TEST-0084 ]
+    capec: [ 37, 167, 191 ]
+    safecode: [ "-" ]
+  -
+    id: "RS3"
+    value: "3"
+    owasp_masvs: [ RESILIENCE-3 ]
+    owasp_mastg: [ TEST-0040, TEST-0083 ]
+    capec: [ 37, 167, 191 ]
+    safecode: [ "-" ]
+  -
+    id: "RS4"
+    value: "4"
+    owasp_masvs: [ RESILIENCE-2 ]
+    owasp_mastg: [ TEST-0038, TEST-0081 ]
+    capec: [ 68, 167, 206, 476 ]
+    safecode: [ 14 ]
+  -
+    id: "RS5"
+    value: "5"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0039, TEST-0082 ]
+    capec: [ 115, 167, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RS6"
+    value: "6"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0046, TEST-0089 ]
+    capec: [ 115, 167, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RS7"
+    value: "7"
+    owasp_masvs: [ RESILIENCE-1 ]
+    owasp_mastg: [ TEST-0049, TEST-0092 ]
+    capec: [ 189, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RS8"
+    value: "8"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0048, TEST-0091 ]
+    capec: [ 167, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RS9"
+    value: "9"
+    owasp_masvs: [ RESILIENCE-3 ]
+    owasp_mastg: [ TEST-0051, TEST-0093 ]
+    capec: [ 167, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RSX"
+    value: "10"
+    owasp_masvs: [ RESILIENCE-1 ]
+    owasp_mastg: [ TEST-0045, TEST-0088 ]
+    capec: [ 167, 660, 661 ]
+    safecode: [ "-" ]
+  -
+    id: "RSJ"
+    value: "J"
+    owasp_masvs: [ RESILIENCE-2 ]
+    owasp_mastg: [ TEST-0047, TEST-0090 ]
+    capec: [ 23, 165, 167 ]
+    safecode: [ "-" ]
+  -
+    id: "RSQ"
+    value: "Q"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0050 ]
+    capec: [ 167, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "RSK"
+    value: "K"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0046, TEST-0089 ]
+    capec: [ 167, 554 ]
+    safecode: [ "-" ]
+-
+  name: "Cryptography"
+  cards:
+  -
+    id: "CRM2"
+    value: "2"
+    owasp_masvs: [ CRYPTO-2 ]
+    owasp_mastg: [  TEST-0015, TEST-0062 ]
+    capec: [ 97, 116, 117 ]
+    safecode: [ 14, 29 ]
+  -
+    id: "CRM3"
+    value: "3"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0014, TEST-0061 ]
+    capec: [ 37, 204 ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CRM4"
+    value: "4"
+    owasp_masvs: [ CRYPTO-1, CODE-4 ]
+    owasp_mastg: [ TEST-0002 ]
+    capec: [ 68, 75, 145, 438, 439, 442 ]
+    safecode: [ 12, 14 ]
+  -
+    id: "CRM5"
+    value: "5"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0016, TEST-0063 ]
+    capec: [ 20, 112, 485 ]
+    safecode: [ 29, 33 ]
+  -
+    id: "CRM6"
+    value: "6"
+    owasp_masvs: [ STORAGE-1,  CRYPTO-1, CRYPTO-2 ]
+    owasp_mastg: [ TEST-0001, TEST-0013, TEST-0052, TEST-0062 ]
+    capec: [ 37, 117, 155, 191, 204 ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CRM7"
+    value: "7"
+    owasp_masvs: [ STORAGE-1, CRYPTO-2 ]
+    owasp_mastg: [ TEST-0001, TEST-0013,  TEST-0052, TEST-0062 ]
+    capec: [ 37, 117, 155, 191, 204 ]
+    safecode: [ 21, 29, 31 ]
+  -
+    id: "CRM8"
+    value: "8"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0013, TEST-0016,  TEST-0063 ]
+    capec: [ 20, 55, 112, 485 ]
+    safecode: [ 21, 29, 32, 33 ]
+  -
+    id: "CRM9"
+    value: "9"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0014 ]
+    capec: [ 97, 620 ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CRMX"
+    value: "10"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0014, TEST-0061 ]
+    capec: [ 20, 116, 117, 97, 112, 485 ]
+    safecode: [ 14, 23, 29, 31, 32, 33 ]
+  -
+    id: "CRMJ"
+    value: "J"
+    owasp_masvs: [ CRYPTO-1, STORAGE-1 ]
+    owasp_mastg: [ TEST-0001, TEST-0014, TEST-0052, TEST-0061 ]
+    capec: [ 210, 212 ]
+    safecode: [ 15 ]
+  -
+    id: "CRMQ"
+    value: "Q"
+    owasp_masvs: [ CRYPTO-1 ]
+    owasp_mastg: [ TEST-0014, TEST-0061 ]
+    capec: [ 20, 116, 117,  97, 112, 485 ]
+    safecode: [ 14, 21, 29, 32, 33 ]
+  -
+    id: "CRMK"
+    value: "K"
+    owasp_masvs: [ CRYPTO-1, CRYPTO-2 ]
+    owasp_mastg: [ TEST-0014, TEST-0061, TEST-0062 ]
+    capec: [ 54, 97, 116, 117, 220 ]
+    safecode: [ 14, 21, 29 ]
+-
+  name: "Cornucopia"
+  cards:
+  -
+    id: "COM2"
+    value: "2"
+    owasp_masvs: [ PRIVACY-3 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 410 ]
+    safecode: [ "-" ]
+  -
+    id: "COM3"
+    value: "3"
+    owasp_masvs: [ PRIVACY-4 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 410 ]
+    safecode: [ "-" ]
+  -
+    id: "COM4"
+    value: "4"
+    owasp_masvs: [ PRIVACY-1 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 410 ]
+    safecode: [ "-" ]
+  -
+    id: "COM5"
+    value: "5"
+    owasp_masvs: [ PRIVACY-4 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 410 ]
+    safecode: [ "-" ]
+  -
+    id: "COM6"
+    value: "6"
+    owasp_masvs: [ PRIVACY-2 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 410 ]
+    safecode: [ "-" ]
+  -
+    id: "COM7"
+    value: "7"
+    owasp_masvs: [ CODE-4, PLATFORM-1 ]
+    owasp_mastg: [ TEST-0025, TEST-0030, TEST-0072 ]
+    capec: [ 499, 502 ]
+    safecode: [ "-" ]
+  -
+    id: "COM8"
+    value: "8"
+    owasp_masvs: [ STORAGE-2 ]
+    owasp_mastg: [ "-" ]
+    capec: [ 126 ]
+    safecode: [ 16 ]
+  -
+    id: "COM9"
+    value: "9"
+    owasp_masvs: [ CODE-4 ]
+    owasp_mastg: [ TEST-0043, TEST-0086 ]
+    capec: [ 92, 100 ]
+    safecode: [ 3, 6, 36 ]
+  -
+    id: "COMX"
+    value: "10"
+    owasp_masvs: [ CODE-4 ]
+    owasp_mastg: [ TEST-0025, TEST-0072 ]
+    capec: [ 137, 499, 502, 586 ]
+    safecode: [ "-" ]
+  -
+    id: "COMJ"
+    value: "J"
+    owasp_masvs: [ CRYPTO-1, CODE-4 ]
+    owasp_mastg: [ TEST-0002 ]
+    capec: [ 23, 165, 442 ]
+    safecode: [ "-" ]
+  -
+    id: "COMQ"
+    value: "Q"
+    owasp_masvs: [ RESILIENCE-4 ]
+    owasp_mastg: [ TEST-0050 ]
+    capec: [ 167, 202, 554 ]
+    safecode: [ "-" ]
+  -
+    id: "COMK"
+    value: "K"
+    owasp_masvs: [ RESILIENCE-2 ]
+    owasp_mastg: [ TEST-0047, TEST-0090 ]
+    capec: [ 17, 23, 165, 167, 636 ]
+    safecode: [ "-" ]

--- a/priv/repo/cornucopia/webapp-cards-2.00-en.yaml
+++ b/priv/repo/cornucopia/webapp-cards-2.00-en.yaml
@@ -1,0 +1,1244 @@
+---
+meta:
+  edition: "webapp"
+  component: "cards"
+  language: "EN"
+  version: "2.00"
+suits:
+-
+  name: "DATA VALIDATION & ENCODING"
+  cards:
+  -
+    id: "DV2"
+    value: "2"
+    desc: "Brian can gather information about the underlying configurations, schemas, logic, code, software, services and infrastructure due to the content of error messages, or poor configuration, or the presence of default installation files or old, test, backup or copies of resources, or exposure of source code"
+  -
+    id: "DV3"
+    value: "3"
+    desc: "Robert can input malicious data because the allowed protocol format is not being checked, or duplicates are accepted, or the structure is not being verified, or the individual data elements are not being validated for format, type, range, length and a whitelist of allowed characters or formats"
+  -
+    id: "DV4"
+    value: "4"
+    desc: "Dave can input malicious field names or data because it is not being checked within the context of the current user and process"
+  -
+    id: "DV5"
+    value: "5"
+    desc: "Jee can bypass the centralized encoding routines since they are not being used everywhere, or the wrong encodings are being used"
+  -
+    id: "DV6"
+    value: "6"
+    desc: "Jason can bypass the centralized validation routines since they are not being used on all inputs"
+  -
+    id: "DV7"
+    value: "7"
+    desc: "Jan can craft special payloads to foil input validation because the character set is not specified/enforced, or the data is encoded multiple times, or the data is not fully converted into the same format the application uses (e.g. canonicalization) before being validated, or variables are not strongly typed"
+  -
+    id: "DV8"
+    value: "8"
+    desc: "Oana can bypass the centralized sanitization routines since they are not being used comprehensively"
+  -
+    id: "DV9"
+    value: "9"
+    desc: "Shamun can bypass input validation or output validation checks because validation failures are not rejected and/or sanitized"
+  -
+    id: "DVX"
+    value: "10"
+    desc: "Darío can exploit the trust the application places in a source of data (e.g. user-definable data, manipulation of locally stored data, alteration to state data on a client device, lack of verification of identity during data validation such as Darío can pretend to be Colin)"
+  -
+    id: "DVJ"
+    value: "J"
+    desc: "Toby has control over input validation, output validation or output encoding code or routines so they can be bypassed"
+  -
+    id: "DVQ"
+    value: "Q"
+    desc: "Xavier can inject data into a client or device side interpreter because a parameterised interface is not being used, or has not been implemented correctly, or the data has not been encoded correctly for the context, or there is no restrictive policy on code or data includes"
+  -
+    id: "DVK"
+    value: "K"
+    desc: "Gabe can inject data into an server-side interpreter (e.g. SQL, OS commands, Xpath, Server JavaScript, SMTP) because a strongly typed parameterised interface is not being used or has not been implemented correctly"
+  -
+    id: "DVA"
+    value: "A"
+    desc: "You have invented a new attack against Data Validation and Encoding"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Input Validation, XSS Prevention, DOM-based XSS Prevention, SQL Injection Prevention, and Query Parameterization"
+-
+  name: "AUTHENTICATION"
+  cards:
+  -
+    id: "AC2"
+    value: "2"
+    desc: "James can undertake authentication functions without the real user ever being aware this has occurred (e.g. attempt to log in, log in with stolen credentials, reset the password) "
+  -
+    id: "AC3"
+    value: "3"
+    desc: "Muhammad can obtain a user's password or other secrets such as security questions, by observation during entry, or from a local cache, or from memory, or in transit, or by reading it from some unprotected location, or because it is widely known, or because it never expires, or because the user cannot change her own password"
+  -
+    id: "AC4"
+    value: "4"
+    desc: "Sebastien can easily identify user names or can enumerate them"
+  -
+    id: "AC5"
+    value: "5"
+    desc: "Javier can use default, test or easily guessable credentials to authenticate, or can use an old account or an account not necessary for the application"
+  -
+    id: "AC6"
+    value: "6"
+    desc: "Sven can reuse a temporary password because the user does not have to change it on first use, or it has too long or no expiry, or it does not use an out-of-band delivery method (e.g. post, mobile app, SMS)"
+  -
+    id: "AC7"
+    value: "7"
+    desc: "Cecilia can use brute force and dictionary attacks against one or many accounts without limit, or these attacks are simplified due to insufficient complexity, length, expiration and re-use requirements for passwords"
+  -
+    id: "AC8"
+    value: "8"
+    desc: "Kate can bypass authentication because it does not fail secure (i.e. it defaults to allowing unauthenticated access)"
+  -
+    id: "AC9"
+    value: "9"
+    desc: "Claudia can undertake more critical functions because authentication requirements are too weak (e.g. do not use strong authentication such as two factor), or there is no requirement to re-authenticate for these"
+  -
+    id: "ACX"
+    value: "10"
+    desc: "Pravin can bypass authentication controls because a centralized standard, tested, proven and approved authentication module/framework/service, separate to the resource being requested, is not being used"
+  -
+    id: "ACJ"
+    value: "J"
+    desc: "Mark can access resources or services because there is no authentication requirement, or it was mistakenly assumed authentication would be undertaken by some other system or performed in some previous action"
+  -
+    id: "ACQ"
+    value: "Q"
+    desc: "Johan can bypass authentication because it is not enforced with equal rigor for all types of authentication functionality (e.g. register, password change, password recovery, log out, administration) or across all versions/channels (e.g. mobile website, mobile app, full website, API, call centre)"
+  -
+    id: "ACK"
+    value: "K"
+    desc: "Olga can influence or alter authentication code/routines so they can be bypassed"
+  -
+    id: "ACA"
+    value: "A"
+    desc: "You have invented a new attack against Authentication"
+    misc: "Read more about this topic in OWASP's free Authentication Cheat Sheet"
+-
+  name: "SESSION MANAGEMENT"
+  cards:
+  -
+    id: "SM2"
+    value: "2"
+    desc: "William has control over the generation of session identifiers"
+  -
+    id: "SM3"
+    value: "3"
+    desc: "Ryan can use a single account in parallel since concurrent sessions are allowed"
+  -
+    id: "SM4"
+    value: "4"
+    desc: "Alison can set session identification cookies on another web application because the domain and path are not restricted sufficiently"
+  -
+    id: "SM5"
+    value: "5"
+    desc: "John can predict or guess session identifiers because they are not changed when the user's role alters (e.g. pre and post authentication) and when switching between non-encrypted and encrypted communications, or are not sufficiently long and random, or are not changed periodically"
+  -
+    id: "SM6"
+    value: "6"
+    desc: "Gary can take over a user's session because there is a long or no inactivity timeout, or a long or no overall session time limit, or the same session can be used from more than one device/location"
+  -
+    id: "SM7"
+    value: "7"
+    desc: "Graham can utilize Adam's session after he has finished, because there is no log out function, or he cannot easily log out, or log out does not properly terminate the session"
+  -
+    id: "SM8"
+    value: "8"
+    desc: "Matt can abuse long sessions because the application does not require periodic re-authentication to check if privileges have changed"
+  -
+    id: "SM9"
+    value: "9"
+    desc: "Ivan can steal session identifiers because they are sent over insecure channels, or are logged, or are revealed in error messages, or are included in URLs, or are accessible un-necessarily by code which the attacker can influence or alter"
+  -
+    id: "SMX"
+    value: "10"
+    desc: "Marce can forge requests because per-session, or per-request for more critical actions, strong random tokens (i.e. anti-CSRF tokens) or similar are not being used for actions that change state"
+  -
+    id: "SMJ"
+    value: "J"
+    desc: "Jeff can resend an identical repeat interaction (e.g. HTTP request, signal, button press) and it is accepted, not rejected"
+  -
+    id: "SMQ"
+    value: "Q"
+    desc: "Salim can bypass session management because it is not applied comprehensively and consistently across the application"
+  -
+    id: "SMK"
+    value: "K"
+    desc: "Peter can bypass the session management controls because they have been self-built and/or are weak, instead of using a standard framework or approved tested module"
+  -
+    id: "SMA"
+    value: "A"
+    desc: "You have invented a new attack against Session Management"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Session Management, and Cross Site Request Forgery (CSRF) Prevention"
+-
+  name: "AUTHORIZATION"
+  cards:
+  -
+    id: "AZ2"
+    value: "2"
+    desc: "Tim can influence where data is sent or forwarded to"
+  -
+    id: "AZ3"
+    value: "3"
+    desc: "Christian can access information, which he should not have permission to, through another mechanism that does have permission (e.g. search indexer, logger, reporting), or because it is cached, or kept for longer than necessary, or through other information leakage"
+  -
+    id: "AZ4"
+    value: "4"
+    desc: "Kelly can bypass authorization controls because they do not fail securely (i.e. they default to allowing access)"
+  -
+    id: "AZ5"
+    value: "5"
+    desc: "Chad can access resources (including services, processes, AJAX, Flash, video, images, documents, temporary files, session data, system properties, configuration data, registry settings, logs) he should not be able to due to missing authorization, or due to excessive privileges (e.g. not using the principle of least privilege)"
+  -
+    id: "AZ6"
+    value: "6"
+    desc: "Eduardo can access data he does not have permission to, even though he has permission to the form/page/URL/entry point"
+  -
+    id: "AZ7"
+    value: "7"
+    desc: "Yuanjing can access application functions, objects, or properties he is not authorized to access"
+  -
+    id: "AZ8"
+    value: "8"
+    desc: "Tom can bypass business rules by altering the usual process sequence or flow, or by undertaking the process in the incorrect order, or by manipulating date and time values used by the application, or by using valid features for unintended purposes, or by otherwise manipulating control data"
+  -
+    id: "AZ9"
+    value: "9"
+    desc: "Mike can misuse an application by using a valid feature too fast, or too frequently, or other way that is not intended, or consumes the application's resources, or causes race conditions, or over-utilizes a feature"
+  -
+    id: "AZX"
+    value: "10"
+    desc: "Richard can bypass the centralized authorization controls since they are not being used comprehensively on all interactions"
+  -
+    id: "AZJ"
+    value: "J"
+    desc: "Dinis can access security configuration information, or access control lists"
+  -
+    id: "AZQ"
+    value: "Q"
+    desc: "Christopher can inject a command that the application will run at a higher privilege level"
+  -
+    id: "AZK"
+    value: "K"
+    desc: "Ryan can influence or alter authorization controls and permissions, and can therefore bypass them"
+  -
+    id: "AZA"
+    value: "A"
+    desc: "You have invented a new attack against Authorization"
+    misc: "Read more about this topic in OWASP's Development and Testing Guides"
+-
+  name: "CRYPTOGRAPHY"
+  cards:
+  -
+    id: "CR2"
+    value: "2"
+    desc: "Kyun can access data because it has been obfuscated rather than using an approved cryptographic function"
+  -
+    id: "CR3"
+    value: "3"
+    desc: "Axel can modify transient or permanent data (stored or in transit), or source code, or updates/patches, or configuration data, because it is not subject to integrity checking"
+  -
+    id: "CR4"
+    value: "4"
+    desc: "Paulo can access data in transit that is not encrypted, even though the channel is encrypted"
+  -
+    id: "CR5"
+    value: "5"
+    desc: "Kyle can bypass cryptographic controls because they do not fail securely (i.e. they default to unprotected)"
+  -
+    id: "CR6"
+    value: "6"
+    desc: "Romain can read and modify unencrypted data in memory or in transit (e.g. cryptographic secrets, credentials, session identifiers, personal and commercially-sensitive data), in use or in communications within the application, or between the application and users, or between the application and external systems"
+  -
+    id: "CR7"
+    value: "7"
+    desc: "Gunter can intercept or modify encrypted data in transit because the protocol is poorly deployed, or weakly configured, or certificates are invalid, or certificates are not trusted, or the connection can be degraded to a weaker or un-encrypted communication"
+  -
+    id: "CR8"
+    value: "8"
+    desc: "Eoin can access stored business data (e.g. passwords, session identifiers, PII, cardholder data) because it is not securely encrypted or securely hashed"
+  -
+    id: "CR9"
+    value: "9"
+    desc: "Andy can bypass random number generation, random GUID generation, hashing and encryption functions because they have been self-built and/or are weak"
+  -
+    id: "CRX"
+    value: "10"
+    desc: "Susanna can break the cryptography in use because it is not strong enough for the degree of protection required, or it is not strong enough for the amount of effort the attacker is willing to make"
+  -
+    id: "CRJ"
+    value: "J"
+    desc: "Justin can read credentials for accessing internal or external resources, services and others systems because they are stored in an unencrypted format, or saved in the source code"
+  -
+    id: "CRQ"
+    value: "Q"
+    desc: "Artim can access or predict the master cryptographic secrets"
+  -
+    id: "CRK"
+    value: "K"
+    desc: "Dan can influence or alter cryptography code/routines (encryption, hashing, digital signatures, random number and GUID generation) and can therefore bypass them"
+  -
+    id: "CRA"
+    value: "A"
+    desc: "You have invented a new attack against Cryptography"
+    misc: "Read more about this topic in OWASP's free Cheat Sheets on Cryptographic Storage, and Transport Layer Protection"
+-
+  name: "CORNUCOPIA"
+  cards:
+  -
+    id: "CO2"
+    value: "2"
+    desc: "Lee can bypass application controls because dangerous/risky programming language functions have been used instead of safer alternatives, or there are type conversion errors, or because the application is unreliable when an external resource is unavailable, or there are race conditions, or there are resource initialization or allocation issues, or overflows can occur"
+  -
+    id: "CO3"
+    value: "3"
+    desc: "Andrew can access source code, or decompile, or otherwise access business logic to understand how the application works and any secrets contained"
+  -
+    id: "CO4"
+    value: "4"
+    desc: "Keith can perform an action and it is not possible to attribute it to him"
+  -
+    id: "CO5"
+    value: "5"
+    desc: "Larry can influence the trust other parties including users have in the application, or abuse that trust elsewhere (e.g. in another application)"
+  -
+    id: "CO6"
+    value: "6"
+    desc: "Aaron can bypass controls because error/exception handling is missing, or is implemented inconsistently or partially, or does not deny access by default (i.e. errors should terminate access/execution), or relies on handling by some other service or system"
+  -
+    id: "CO7"
+    value: "7"
+    desc: "Mwengu's actions cannot be investigated because there is not an adequate accurately time-stamped record of security events, or there is not a full audit trail, or these can be altered or deleted by Mwengu, or there is no centralized logging service"
+  -
+    id: "CO8"
+    value: "8"
+    desc: "David can bypass the application to gain access to data because the network and host infrastructure, and supporting services/applications, have not been securely configured, the configuration rechecked periodically and security patches applied, or the data is stored locally, or the data is not physically protected"
+  -
+    id: "CO9"
+    value: "9"
+    desc: "Michael can bypass the application to gain access to data because administrative tools or administrative interfaces are not secured adequately"
+  -
+    id: "COX"
+    value: "10"
+    desc: "Spyros can circumvent the application's controls because code frameworks, libraries and components contain malicious code or vulnerabilities (e.g. in-house, commercial off the shelf, outsourced, open source, externally-located)"
+  -
+    id: "COJ"
+    value: "J"
+    desc: "Roman can exploit the application because it was compiled using out-of-date tools, or its configuration is not secure by default, or security information was not documented and passed on to operational teams"
+  -
+    id: "COQ"
+    value: "Q"
+    desc: "Jim can undertake malicious, non-normal, actions without real-time detection and response by the application"
+  -
+    id: "COK"
+    value: "K"
+    desc: "Grant can utilize the application to deny service to some or all of its users"
+  -
+    id: "COA"
+    value: "A"
+    desc: "You have invented a new attack of any type"
+    misc: "Read more about application security in OWASP's free Guides on Requirements, Development, Code Review and Testing, the Cheat Sheet series, and the Open Software Assurance Maturity Model"
+-
+  name: "WILD CARD"
+  cards:
+  -
+    id: "JOA"
+    value: "JokerA"
+    card: "Joker"
+    desc: "Alice can utilize the application to attack users' systems and data"
+    misc: "Have you thought about becoming an individual OWASP member? All tools, guidance and local meetings are free for everyone, but individual membership helps support OWASP's work"
+  -
+    id: "JOB"
+    value: "JokerB"
+    card: "Joker"
+    desc: "Bob can influence, alter or affect the application so that it no longer complies with legal, regulatory, contractual or other organizational mandates"
+    misc: "Examine vulnerabilities and discover how they can be fixed using the free OWASP® Juice Shop, Security Shepherd, or using the online challenges in the free OWASP® Hacking-lab"
+paragraphs:
+-
+  name: "Common"
+  sentences:
+  -
+    value: "NoCard"
+    text: "No Card"
+  -
+    value: "Title"
+    text: "Website App Edition v2.00-EN"
+  -
+    value: "Title_full"
+    text: "OWASP® Cornucopia Website App Edition v2.00-EN"
+  -
+    value: "T00005"
+    text: "Index"
+  -
+    value: "T00005"
+    text: "Index"
+  -
+    value: "T00010"
+    text: "OWASP® Cornucopia is a mechanism to assist software development teams identify security requirements in Agile, conventional and formal development processes."
+  -
+    value: "T00020"
+    text: "Author"
+  -
+    value: "T00030"
+    text: "Project Leaders"
+  -
+    value: "T00100"
+    text: "Acknowledgements"
+  -
+    value: "T00110"
+    text: "Adam Shostack and the Microsoft SDL Team for the “Elevation of Privilege Threat Modelling Game”, published under a Creative Commons Attribution license, as the inspiration for Cornucopia and from which many ideas, especially the game theory, were copied."
+  -
+    value: "T00120"
+    text: "Keith Turpin and contributors to the OWASP® “Secure Coding Practices - Quick Reference Guide”, originally donated to OWASP by Boeing, which is used as the primary source of security requirements information to formulate the content of the cards."
+  -
+    value: "T00130"
+    text: "Contributors, supporters, sponsors and volunteers to the OWASP® ASVS, AppSensor and Web Framework Security Matrix projects, Mitre's Common Attack Pattern Enumeration and Classification (CAPEC), and SAFECode's “Practical Security Stories and Security Tasks for Agile Development Environments” which are all used in the cross-references provided."
+  -
+    value: "T00140"
+    text: "Playgen for providing an illuminating afternoon seminar on task gamification, and tartanmaker.com for the online tool to help create the card back pattern."
+  -
+    value: "T00145"
+    text: "Current and past OWASP® Cornucopia project contributors and leaders, especially those involved most recently updating the cross-references, creating online versions, and writing scripts to dynamically generate Cornucopia's output files."
+  -
+    value: "T00150"
+    text: "Blackfoot (UK) Limited for creating and donating print-ready design files, Tom Brennan and the OWASP® Foundation for instigating the creation of an OWASP-branded box and leaflet, and Secure Delivery Ltd for developing and donating Copi, the platform to play Cornucopia and EoP online."
+  -
+    value: "T00161"
+    text: "(continued on page 20)"
+  -
+    value: "T00162"
+    text: "(continued from page 10)"
+  -
+    value: "T00170"
+    text: "Colin Watson as author and co-project leader with Grant Ongers along with other OWASP volunteers who have helped in many ways."
+  -
+    value: "T00180"
+    text: "OWASP® does not endorse or recommend commercial products or services © 2012-2024 OWASP® Foundation This document is licensed under the Creative Commons Attribution-ShareAlike 3.0 license"
+  -
+    value: "T00200"
+    text: "Introduction"
+  -
+    value: "T00210"
+    text: "The idea behind Cornucopia is to help development teams, especially those using Agile methodologies, to identify application security requirements and develop security-based user stories."
+  -
+    value: "T00220"
+    text: "Although the idea had been waiting for enough time to progress it, the final motivation came when SAFECode published its Practical Security Stories and Security Tasks for Agile Development Environments in July 2012."
+  -
+    value: "T00230"
+    text: "The Microsoft SDL team had already published its super Elevation of Privilege: The Threat Modeling Game (EoP) but that did not seem to address the most appropriate kind of issues that web application development teams mostly have to address."
+  -
+    value: "T00240"
+    text: "EoP is a great concept and game strategy, and was published under a Creative Commons Attribution License."
+  -
+    value: "T00250"
+    text: "Cornucopia Website App Edition is based the concepts and game ideas in EoP, but those have been modified to be more relevant to the types of issues webapp website developers encounter."
+  -
+    value: "T00260"
+    text: "It attempts to introduce threat-modelling ideas into development teams that use Agile methodologies, or are more focused on web application weaknesses than other types of software vulnerabilities or are not familiar with STRIDE and DREAD."
+  -
+    value: "T00270"
+    text: "Cornucopia Website App Edition is referenced as an information resource in the PCI Security Standard Council's Information Supplement PCI DSS E-commerce Guidelines, v2, January 2013."
+  -
+    value: "T00300"
+    text: "The card deck (pack)"
+  -
+    value: "T00310"
+    text: "Instead of EoP's STRIDE suits (sets of cards with matching designs), Cornucopia suits are based on the structure of the OWASP® Secure Coding Practices - Quick Reference Guide (SCP), but with additional consideration of sections in the OWASP® Application Security Verification Standard, the Web Security Testing Guide (WSTG) and David Rook's Principles of Secure Development. "
+  -
+    value: "T00320"
+    text: "These provided five suits, and a sixth called “Cornucopia” was created for everything else: "
+  -
+    value: "T00330"
+    text: "Data Validation and Encoding (VE)"
+  -
+    value: "T00340"
+    text: "Authentication (AT)"
+  -
+    value: "T00350"
+    text: "Session Management (SM)"
+  -
+    value: "T00360"
+    text: "Authorization (AZ)"
+  -
+    value: "T00370"
+    text: "Cryptography (CR)"
+  -
+    value: "T00380"
+    text: "Cornucopia (C)"
+  -
+    value: "T00390"
+    text: "Smilar to poker-playing cards, each suit contains 13 cards (Ace, 2-10, Jack, Queen and King) but, unlike EoP, there are also two Joker cards."
+  -
+    value: "T00400"
+    text: "The content was mainly drawn from the SCP."
+  -
+    value: "T00500"
+    text: "Mappings"
+  -
+    value: "T00510"
+    text: "The other driver for Cornucopia is to link the attacks with requirements and verification techniques."
+  -
+    value: "T00520"
+    text: "An initial aim had been to reference CWE weakness IDs, but these proved too numerous, and instead it was decided to map each card to CAPEC software attack pattern IDs which themselves are mapped to CWEs, so the desired result is achieved."
+  -
+    value: "T00530"
+    text: "Each card is also mapped to the 36 primary security stories in the SAFECode document, as well as to the OWASP® SCP v2, ASVS v4.0 and AppSensor (application attack detection and response) to help teams create their own security-related stories for use in Agile processes."
+  -
+    value: "T00600"
+    text: "Game strategy"
+  -
+    value: "T00610"
+    text: "Apart from the content differences, the game rules are virtually identical to those for EoP."
+  -
+    value: "T00700"
+    text: "Printing the cards"
+  -
+    value: "T00710"
+    text: "Check the Cornucopia project page for how to obtain pre-printed decks on glossy card."
+  -
+    value: "T00720"
+    text: "The cards can be printed from this document in black & white but are more effective in color."
+  -
+    value: "T00730"
+    text: "The cards in the later pages of this document have been laid out to fit on one type of pre-scored business A4 card sheets. "
+  -
+    value: "T00740"
+    text: "This appeared to be the quickest way to initially provide to create playing cards quickly. "
+  -
+    value: "T00750"
+    text: "Avery product codes C32015 and C32030 have been tested successfully, but any 10 up 85mm x 54 mm cards on A4 paper should work with a little adjustment."
+  -
+    value: "T00760"
+    text: "Other stationery suppliers like Ryman and Sigel produce similar sheets"
+  -
+    value: "T00770"
+    text: "These card sheets are not inexpensive, so care should be taken in deciding what to print and using what media and printer type."
+  -
+    value: "T00780"
+    text: "The cards can of course just be printed on any size of paper or card and then cut-up manually, or a commercial printer would be able to print larger volumes and cut the cards to size. "
+  -
+    value: "T00790"
+    text: "The cut lines are shown on the penultimate page of this document, but Avery also produce a landscape A4 template (A-0017-01_L.doc) that can be used as a guide."
+  -
+    value: "T00800"
+    text: "Printing and cutting up can take an hour or so, and using a faster printer helps."
+  -
+    value: "T00810"
+    text: "Try to print add higher quality to increase legibility."
+  -
+    value: "T00820"
+    text: "An optional card back design (in OWASP® tartan) has been provided as the last page of this document."
+  -
+    value: "T00830"
+    text: "There is no special alignment needed. "
+  -
+    value: "T00840"
+    text: "Dual-sided printing needs special care taken. "
+  -
+    value: "T00850"
+    text: "You could customize the card faces or the backs for your own organization's preferences."
+  -
+    value: "T00900"
+    text: "Customization"
+  -
+    value: "T00910"
+    text: "After you have used Cornucopia a few times, you may feel that some cards are less relevant to your applications, or the threats are different for your organization."
+  -
+    value: "T00920"
+    text: "Edit this document yourself to make the cards more suitable for your teams, or create new decks completely."
+  -
+    value: "T01000"
+    text: "Provide feedback"
+  -
+    value: "T01010"
+    text: "If you have ideas or feedback on the use of OWASP® Cornucopia, please share them."
+  -
+    value: "T01020"
+    text: "Even better if you create alternative versions of the cards, or produce professional print-ready versions, please share that with the volunteers who created this edition and with the wider application development and application security community."
+  -
+    value: "T01030"
+    text: "The best place to use to discuss or contribute is the list/group for the OWASP project:"
+  -
+    value: "T01040"
+    text: "List/Group"
+  -
+    value: "T01050"
+    text: "Project home page"
+  -
+    value: "T01060"
+    text: "All OWASP documents and tools are free to download and use."
+  -
+    value: "T01070"
+    text: "OWASP® Cornucopia is licensed under the Creative Commons Attribution-ShareAlike 3.0 license."
+  -
+    value: "T01100"
+    text: "Instructions"
+  -
+    value: "T01110"
+    text: "The text on each card describes an attack, but the attacker is given a name, which are unique across all the cards."
+  -
+    value: "T01120"
+    text: "The name can represent a computer system (e.g. the database, the file system, another application, a related service, a botnet), an individual person (e.g. a citizen, a customer, a client, an employee, a criminal, a spy), or even a group of people (e.g. a competitive organization, activists with a common cause)."
+  -
+    value: "T01130"
+    text: "The attacker might be remote in some other device/location, or local/internal with access to the same device, host or network as the application is running on."
+  -
+    value: "T01140"
+    text: "The attacker is always named at the start of each description"
+  -
+    value: "T01150"
+    text: "An example is:"
+  -
+    value: "T01160"
+    text: "William has control over the generation of session identifiers."
+  -
+    value: "T01170"
+    text: "This means the attacker (William) can create new session identifiers that the application accepts."
+  -
+    value: "T01180"
+    text: "The attacks were primarily drawn from the security requirements listed in the SCP, v2 but then supplemented with verification objectives from the OWASP® “Application Security Verification Standard”, the security focused stories in SAFECode's “Practical Security Stories and Security Tasks for Agile Development Environments”, and finally a review of the cards in EOP."
+  -
+    value: "T01190"
+    text: "Further guidance about each card is available in the online Wiki Deck at "
+  -
+    value: "T01200"
+    text: "Lookups between the attacks and five resources are provided on most cards:"
+  -
+    value: "T01210"
+    text: "Requirements in “Secure Coding Practices (SCP) - Quick Reference Guide”, v2, OWASP®, November 2010 "
+  -
+    value: "T01220"
+    text: "Verification IDs in OWASP® “Application Security Verification Standard”"
+  -
+    value: "T01230"
+    text: "Attack detection points IDs in “AppSensor”, OWASP®, August 2010-2015"
+  -
+    value: "T01240"
+    text: "IDs in “Common Attack Pattern Enumeration and Classification (CAPEC)”, v2.8, Mitre Corporation, November 2015"
+  -
+    value: "T01250"
+    text: "Security-focused stories in 'Practical Security Stories and Security Tasks for Agile Development Environments', SAFECode, July 2012"
+  -
+    value: "T01260"
+    text: "A look-up means the attack is included within the referenced item, but does not necessarily encompass the whole of its intent. "
+  -
+    value: "T01270"
+    text: "For structured data like CAPEC, the most specific reference is provided but sometimes a cross-reference is provided that also has more specific (child) examples."
+  -
+    value: "T01280"
+    text: "There are no lookups on the six Aces and two Jokers. "
+  -
+    value: "T01290"
+    text: "Instead these cards have some general tips in italicized text."
+  -
+    value: "T01300"
+    text: "It is possible to play Cornucopia in many different ways. "
+  -
+    value: "T01301"
+    text: "For how to play, read pages: 11-19."
+  -
+    value: "T01310"
+    text: "Here is one way, demonstrated online in a video at "
+  -
+    value: "T01311"
+    text: " which uses the new (May 2015) score/record sheet at "
+  -
+    value: "T01400"
+    text: "Preparations"
+  -
+    value: "T01410"
+    text: "Obtain a deck, or print your own deck of Cornucopia cards (see page 2 of this document) and separate/cut out the cards"
+  -
+    value: "T01411"
+    text: "Use the cards in this pack"
+  -
+    value: "T01420"
+    text: "Identify an application or application process to review; this might be a concept, design or an actual implementation"
+  -
+    value: "T01430"
+    text: "Create a data flow diagram, user stories, or other artefacts to help the review"
+  -
+    value: "T01440"
+    text: "Identify and invite a group of 3-6 architects, developers, testers and other business stakeholders together and sit around a table (try to include someone fairly familiar with application security)"
+  -
+    value: "T01450"
+    text: "Have some prizes to hand (gold stars, chocolate, pizza, beer or flowers depending upon your office culture)"
+  -
+    value: "T01500"
+    text: "Play"
+  -
+    value: "T01510"
+    text: "One suit - Cornucopia - acts as trumps."
+  -
+    value: "T01520"
+    text: "Aces are high (i.e. they beat Kings)."
+  -
+    value: "T01530"
+    text: "It helps if there is a non-player to document the issues and scores."
+  -
+    value: "T01540"
+    text: "Remove the Jokers and a few low-score (2, 3, 4) cards from Cornucopia suit to ensure each player will have the same number of cards"
+  -
+    value: "T01550"
+    text: "Shuffle the deck and deal all the cards"
+  -
+    value: "T01560"
+    text: "To begin, choose a player randomly who will play the first card - they can play any card from their hand except from the trump suit - Cornucopia"
+  -
+    value: "T01570"
+    text: "To play a card, each player must read it out aloud, and explain (see the online Wiki Deck for tips) how the threat could apply (the player gets a point for attacks that might work which the group thinks is an actionable bug) - do not try to think of mitigations at this stage, and do not exclude a threat just because of a belief that it is already mitigated - someone note the card and record the issues raised"
+  -
+    value: "T01580"
+    text: "Play clockwise, each person must play a card in the same way; if you have any card of the matching lead suit you must play one of those, otherwise they can play a card from any other suit. "
+  -
+    value: "T01590"
+    text: "Only a higher card of the same suit, or the highest card in the trump suit Cornucopia, wins the hand."
+  -
+    value: "T01600"
+    text: "The person who wins the round, leads the next round (i.e. they play first), and thus defines the next lead suit"
+  -
+    value: "T01610"
+    text: "Repeat until all the cards are played"
+  -
+    value: "T01700"
+    text: "Scoring"
+  -
+    value: "T01710"
+    text: "The objective is to identify applicable threats, and win hands (rounds):"
+  -
+    value: "T01720"
+    text: "Score +1 for each card you can identify as a valid threat to the application under consideration"
+  -
+    value: "T01730"
+    text: "Score +1 if you win a round"
+  -
+    value: "T01740"
+    text: "Once all cards have been played, whoever has the most points wins"
+  -
+    value: "T01800"
+    text: "Closure"
+  -
+    value: "T01810"
+    text: "Review all the applicable threats and the matching security requirements"
+  -
+    value: "T01820"
+    text: "Create user stories, specifications and test cases as required for your development methodology."
+  -
+    value: "T01900"
+    text: "Alternative game rules"
+  -
+    value: "T01910"
+    text: "If you are new to the game, remove the Aces and two Joker cards to begin with."
+  -
+    value: "T01920"
+    text: "Add the Joker cards back in once people become more familiar with the process."
+  -
+    value: "T01930"
+    text: "Apart from the “trumps card game” rules described above which are very similar to the EoP, the deck can also be played as the “twenty-one card game” (also known as “pontoon” or “blackjack”) which normally reduces the number of cards played in each round."
+  -
+    value: "T01940"
+    text: "Practice on an imaginary application, or even a future planned application, rather than trying to find fault with existing applications until the participants are happy with the usefulness of the game."
+  -
+    value: "T01950"
+    text: "Consider just playing with one suit to make a shorter session - but try to cover all the suits for every project. "
+  -
+    value: "T01960"
+    text: "Or even better just play one hand with some pre-selected cards, and score only on the ability to identify security requirements. "
+  -
+    value: "T01970"
+    text: "Perhaps have one game of each suit each day for a week or so, if the participants cannot spare long enough for a full deck."
+  -
+    value: "T01980"
+    text: "Some teams have preferred to play a full hand of cards, and then discuss what is on the cards after each round (instead of after each person plays a card)."
+  -
+    value: "T01990"
+    text: "Another suggestion is that if a player fails to identify the card is relevant, allow other players to suggest ideas, and potentially let them gain the point for the card. "
+  -
+    value: "T02000"
+    text: "Consider allowing extra points for especially good contributions."
+  -
+    value: "T02010"
+    text: "You can even play by yourself. "
+  -
+    value: "T02020"
+    text: "Just use the cards to act as thought-provokers. "
+  -
+    value: "T02030"
+    text: "Involving more people will be beneficial though."
+  -
+    value: "T02040"
+    text: "In Microsoft's EoP guidance, they recommend cheating as a good game strategy."
+  -
+    value: "T02100"
+    text: "Development framework-specific modified card decks"
+  -
+    value: "T02110"
+    text: "There can be built in security controls in some commonly used languages and frameworks for web and mobile application development."
+  -
+    value: "T02120"
+    text: "With certain provisos it is useful to consider how using these controls can simplify the identification of additional requirements – provided of course the controls are included, enabled and configured correctly."
+  -
+    value: "T02130"
+    text: "Consider removing cards from the decks if you are confident they are addressed by the way you are using the language/framework."
+  -
+    value: "T02140"
+    text: "Items in parentheses are “maybes”."
+  -
+    value: "T02200"
+    text: "Internal coding standards and libraries"
+  -
+    value: "T02210"
+    text: "Add your own list of excluded cards based on your organisation's coding standards (provided they are confirmed by appropriate verification steps in the development lifecycle)."
+  -
+    value: "T02220"
+    text: "Your coding standards and libraries"
+  -
+    value: "T02230"
+    text: "Data Validation and Encoding"
+  -
+    value: "T02240"
+    text: "[your list]"
+  -
+    value: "T02250"
+    text: "Authentication"
+  -
+    value: "T02260"
+    text: "[your list]"
+  -
+    value: "T02270"
+    text: "Session Management"
+  -
+    value: "T02280"
+    text: "[your list]"
+  -
+    value: "T02290"
+    text: "Authorization"
+  -
+    value: "T02300"
+    text: "[your list]"
+  -
+    value: "T02310"
+    text: "Cryptography"
+  -
+    value: "T02320"
+    text: "[your list]"
+  -
+    value: "T02330"
+    text: "Cornucopia"
+  -
+    value: "T02340"
+    text: "[your list]"
+  -
+    value: "T02400"
+    text: "Compliance requirement decks"
+  -
+    value: "T02410"
+    text: "Create a smaller deck by only including cards for a particular compliance requirement."
+  -
+    value: "T02420"
+    text: "Compliance requirement"
+  -
+    value: "T02430"
+    text: "Data validation and Encoding"
+  -
+    value: "T02440"
+    text: "[compliance list]"
+  -
+    value: "T02450"
+    text: "Authentication"
+  -
+    value: "T02460"
+    text: "[compliance list]"
+  -
+    value: "T02470"
+    text: "Session Management"
+  -
+    value: "T02480"
+    text: "[compliance list]"
+  -
+    value: "T02490"
+    text: "Authorization"
+  -
+    value: "T02500"
+    text: "[compliance list]"
+  -
+    value: "T02510"
+    text: "Cryptography"
+  -
+    value: "T02520"
+    text: "[compliance list]"
+  -
+    value: "T02530"
+    text: "Cornucopia"
+  -
+    value: "T02540"
+    text: "[compliance list]"
+  -
+    value: "T02600"
+    text: "Frequently asked questions"
+  -
+    value: "T02610"
+    text: "1. Can I copy or edit the game?"
+  -
+    value: "T02620"
+    text: "Yes of course."
+  -
+    value: "T02630"
+    text: "All OWASP materials are free to do with as you like provided you comply with the Creative Commons Attribution-ShareAlike 3.0 license. "
+  -
+    value: "T02640"
+    text: "Perhaps if you create a new version, you might donate it to the OWASP® Cornucopia Project?"
+  -
+    value: "T02650"
+    text: "2. How can I get involved?"
+  -
+    value: "T02660"
+    text: "Please send ideas or offers of help to the project's mailing list."
+  -
+    value: "T02670"
+    text: "3. How were the attackers' names chosen?"
+  -
+    value: "T02680"
+    text: "EoP begins every description with words like 'An attacker can...'. "
+  -
+    value: "T02690"
+    text: "These have to be phrased as an attack but I was not keen on the anonymous terminology, wanting something more engaging, and therefore used personal names. "
+  -
+    value: "T02700"
+    text: "These can be thought of as external or internal people or aliases for computer systems. But instead of just random names, I thought how they might reflect the OWASP community aspect. "
+  -
+    value: "T02710"
+    text: "Therefore, apart from 'Alice and Bob' I use the given (first) names of current and recent OWASP employees and Board members (assigned in no order), and then randomly selected the remaining 50 or so names from the current list of paying individual OWASP members. "
+  -
+    value: "T02720"
+    text: "No name was used more than once, and where people had provided two personal names, I dropped one part to try to ensure no-one can be easily identified. "
+  -
+    value: "T02730"
+    text: "Names were not deliberately allocated to any particular attack, defence or requirement. The cultural and gender mix simply reflects theses sources of names, and is not meant to be world-representative."
+  -
+    value: "T02740"
+    text: "In v1.20, the name on VE-10 changed to reflect the project's new co-leader - this card is also the only one with two names in the attack."
+  -
+    value: "T02750"
+    text: "4. Why aren't there any images on the card faces?"
+  -
+    value: "T02760"
+    text: "There is quite a lot of text on the cards, and the cross-referencing takes up space too."
+  -
+    value: "T02770"
+    text: "But it would be great to have additional design elements included."
+  -
+    value: "T02790"
+    text: "5. Are the attacks ranked by the number on the card?"
+  -
+    value: "T02800"
+    text: "Only approximately."
+  -
+    value: "T02810"
+    text: "The risk will be application and organisation dependent, due to varying security and compliance requirements, so your own severity rating may place the cards in some other order than the numbers on the cards."
+  -
+    value: "T02820"
+    text: "6. How long does it take to play a round of cards using the full deck?"
+  -
+    value: "T02830"
+    text: "This depends upon the scope of the application, amount of discussion and how familiar the players are with application security concepts."
+  -
+    value: "T02840"
+    text: "But perhaps allow 1.5 to 2.0 hours for 4-6 people."
+  -
+    value: "T02850"
+    text: "7. What sort of people should play the game?"
+  -
+    value: "T02860"
+    text: "Always try to have a mix of roles who can contribute alternative perspectives."
+  -
+    value: "T02870"
+    text: "But include someone who has a reasonable knowledge of application vulnerability terminology. "
+  -
+    value: "T02880"
+    text: "Otherwise try to include a mix of architects, developers, testers and a relevant project manager or business owner."
+  -
+    value: "T02890"
+    text: "8. Who should take notes and record scores?"
+  -
+    value: "T02900"
+    text: "It is better if that someone else, not playing the game, takes notes about the requirements identified and issues discussed."
+  -
+    value: "T02910"
+    text: "This could be used as training for a more junior developer, or performed by the project manager."
+  -
+    value: "T02920"
+    text: "Some organisations have made a recording to review afterwards when the requirements are written up more formally."
+  -
+    value: "T02930"
+    text: "9. Should we always use the full deck of cards?"
+  -
+    value: "T02940"
+    text: "No. "
+  -
+    value: "T02950"
+    text: "A smaller deck is quicker to play. "
+  -
+    value: "T02960"
+    text: "Start your first game with only enough cards for two or three rounds. "
+  -
+    value: "T02970"
+    text: "Always consider removing cards that are not appropriate at all of the target application or function being reviewed. "
+  -
+    value: "T02980"
+    text: "For the first few times people play the game it is also usually better to remove the Aces and the two Jokers."
+  -
+    value: "T02990"
+    text: "It is also usual to play the game without any trumps suit until people are more familiar with the idea."
+  -
+    value: "T03000"
+    text: "10. What should players do when they have an Ace card that says “invented a new X attack”?"
+  -
+    value: "T03010"
+    text: "The player can make up any attack they think is valid, but must match the suit of the card (e.g. Data Validation and Encoding)."
+  -
+    value: "T03020"
+    text: "With players new to the game, it can be better to remove these to begin with (see also FAQ 9)."
+  -
+    value: "T03060"
+    text: "11. My company wants to print its own version of OWASP® Cornucopia - what license do we need to refer to?"
+  -
+    value: "T03070"
+    text: "Please refer to the full answer to this question on the project's web pages at"
+  -
+    value: "T03100"
+    text: "Change Log"
+  -
+    value: "T03110"
+    text: "Version / Date"
+  -
+    value: "T03120"
+    text: "Comments"
+  -
+    value: "T03130"
+    text: "0.1"
+  -
+    value: "T03140"
+    text: "Original Draft"
+  -
+    value: "T03150"
+    text: "0.2"
+  -
+    value: "T03160"
+    text: "Draft reviewed and updated"
+  -
+    value: "T03170"
+    text: "0.3"
+  -
+    value: "T03180"
+    text: "Draft announced OWASP® SCP mailing list for comment."
+  -
+    value: "T03190"
+    text: "0.4"
+  -
+    value: "T03200"
+    text: "Play rules updated based on feedback during workshops. "
+  -
+    value: "T03210"
+    text: "Added reference to PCI SSC Information Supplement: PCI DSS E-commerce Guidelines. "
+  -
+    value: "T03220"
+    text: "Descriptive text extended and updated."
+  -
+    value: "T03230"
+    text: "Added contributors section, page numbering, FAQs and change log."
+  -
+    value: "T03240"
+    text: "1"
+  -
+    value: "T03250"
+    text: "Release."
+  -
+    value: "T03260"
+    text: "1.01"
+  -
+    value: "T03270"
+    text: "Framework-specific card deck discussion added"
+  -
+    value: "T03280"
+    text: "Additional FAQs created. "
+  -
+    value: "T03290"
+    text: "Descriptive text updated. "
+  -
+    value: "T03300"
+    text: "New cover image, and previous cover image moved to back. "
+  -
+    value: "T03310"
+    text: "Cut lines added."
+  -
+    value: "T03320"
+    text: "FAQs 5 and 6 added."
+  -
+    value: "T03330"
+    text: "Attack descriptions on cards with tinted backgrounds changed to black (from dark grey). "
+  -
+    value: "T03340"
+    text: "Project contributors added."
+  -
+    value: "T03350"
+    text: "1.02"
+  -
+    value: "T03360"
+    text: "Warning about time to print added. "
+  -
+    value: "T03370"
+    text: "Additional alternative game rules added (twenty-one, play a deck over a week, play full hand and then discuss). "
+  -
+    value: "T03380"
+    text: "Compliance deck concept added. "
+  -
+    value: "T03390"
+    text: "FAQs 5 and 6 added."
+  -
+    value: "T03400"
+    text: "Attack descriptions on cards with tinted backgrounds changed to black (from dark grey). "
+  -
+    value: "T03410"
+    text: "Project contributors added."
+  -
+    value: "T03420"
+    text: "1.03"
+  -
+    value: "T03430"
+    text: "Minor attack wording changes on two cards. "
+  -
+    value: "T03440"
+    text: "OWASP® SCP and ASVS cross-references checked and updated. "
+  -
+    value: "T03450"
+    text: "Code letters added for suits. "
+  -
+    value: "T03460"
+    text: "All remaining attack descriptions on cards changed to black (from dark grey) and background colours amended to provide more contrast and increase readability."
+  -
+    value: "T03470"
+    text: "1.04"
+  -
+    value: "T03480"
+    text: "Text “password change, password change,” corrected to “password change, password recovery,” on Queen of Authentication card. "
+  -
+    value: "T03490"
+    text: "1.05"
+  -
+    value: "T03500"
+    text: "Updates to alternative game rules. "
+  -
+    value: "T03510"
+    text: "Additional FAQs created. "
+  -
+    value: "T03520"
+    text: "Contributors updated. "
+  -
+    value: "T03530"
+    text: "Podcast and video links added."
+  -
+    value: "T03540"
+    text: "1.1"
+  -
+    value: "T03550"
+    text: "Change log date corrected for v1.05. Cross-references updated for 2014 version of ASVS. "
+  -
+    value: "T03560"
+    text: "Contributors updated."
+  -
+    value: "T03570"
+    text: "Minor text changes to cards to improve readability."
+  -
+    value: "T03580"
+    text: "1.2"
+  -
+    value: "T03590"
+    text: "Video mentioned/linked"
+  -
+    value: "T03600"
+    text: "Separate score sheet mentioned/linked. "
+  -
+    value: "T03610"
+    text: "Previous embedded score sheet pages deleted"
+  -
+    value: "T03620"
+    text: "Correction (identified by Tom Brennan) and addition to "
+  -
+    value: "T03630"
+    text: "text on card 8 Authentication. "
+  -
+    value: "T03640"
+    text: "Oana Cornea and other participants at the AppSec EU 2015 project summit added to list of contributors. "
+  -
+    value: "T03650"
+    text: "Darío De Filippis added as project co-leader. "
+  -
+    value: "T03660"
+    text: "Wiki Deck link added"
+  -
+    value: "T03670"
+    text: "Cross-references updated for ASVS v3.0.1 and CAPEC v2.8. Minor text changes to a small number of cards. "
+  -
+    value: "T03680"
+    text: "Added “-EN” to version number in preparation for “-ES” version."
+  -
+    value: "T03690"
+    text: "Susana Romaniz added as a contributor to the Spanish translation."
+  -
+    value: "T03700"
+    text: "Minor text changes to instructions and FAQs."
+  -
+    value: "T03710"
+    text: "2.0"
+  -
+    value: "T03720"
+    text: "Cross-references updated from ASVS v3.0.1 to ASVS v4.0 by Johan Sydseter. "
+  -
+    value: "T03800"
+    text: "Project contributors"
+  -
+    value: "T03810"
+    text: "All OWASP projects rely on the voluntary efforts of people in the software development and information security sectors. "
+  -
+    value: "T03820"
+    text: "They have contributed their time and energy to make suggestions, provide feedback, write, review and edit documentation, give encouragement, trial the game, and promote the concept. "
+  -
+    value: "T03830"
+    text: "Without all their efforts, the project would not have progressed to this point. "
+  -
+    value: "T03840"
+    text: "Please contact the mailing list or project leaders directly, if anyone is missing from the below lists."
+  -
+    value: "T03850"
+    text: "OWASP's hard-working employees."
+  -
+    value: "T03860"
+    text: "Attendees at OWASP® London, OWASP® Manchester, OWASP® Netherlands and OWASP® Scotland chapter meetings, and the London Gamification meetup, who made helpful suggestions and asked challenging questions"
+  -
+    value: "T03870"
+    text: "Blackfoot UK Limited for gifting print-ready design files and hundreds of professionally printed card decks for distribution by post and at OWASP chapter meetings"
+  -
+    value: "T03880"
+    text: 'OWASP® NYC for creating an OWASP box design and distributing packs at AppSec USA 2014.'
+  -
+    value: "T03900"
+    text: "Podcasts and videos"
+  -
+    value: "T03910"
+    text: 'The following supporting OWASP® Cornucopia resources are available online:'
+  -
+    value: "T03920"
+    text: "Video - Using the cards, created during AppSec EU 2015 project summit, 20th May 2015"
+  -
+    value: "T03930"
+    text: "Podcast interview, OWASP® 24/7 Podcast channel, 21st March 2014"
+  -
+    value: "T03940"
+    text: "	Video of presentation, OWASP® EU Tour 2013 London, 3rd June 2013"
+  -
+    value: "T03950"
+    text: "See the project website for further information and presentation materials."

--- a/priv/repo/cornucopia/webapp-mappings-2.00.yaml
+++ b/priv/repo/cornucopia/webapp-mappings-2.00.yaml
@@ -1,0 +1,604 @@
+---
+meta:
+  edition: "webapp"
+  component: "mappings"
+  language: "ALL"
+  version: "2.00"
+  layouts: ["cards", "leaflet", "guide"]
+  templates: ["bridge_qr", "bridge", "tarot"]
+  languages: ["en", "es", "fr", "nl", "nl", "no-nb", "pt-br"]
+suits:
+-
+  name: "DATA VALIDATION & ENCODING"
+  cards:
+  -
+    id: "DV2"
+    value: "2"
+    owasp_scp: [ 69, 107-109, 136, 137, 153, 156, 158, 162 ]
+    owasp_asvs: [ 1.6.4, 2.10.4, 4.3.2, 7.1.1, 10.2.3, 14.1.1, 14.2.2, 14.3.3 ]
+    owasp_appsensor: [ HT1-3 ]
+    capec: [ 54, 541 ]
+    safecode: [ 4, 23 ]
+  -
+    id: "DV3"
+    value: "3"
+    owasp_scp: [ ]
+    owasp_asvs: [ 1.5.3, 5.1.1-4, 13.2.1, 14.1.2, 14.4.1 ]
+    owasp_appsensor: [ RE7-8, AE4-7, IE2-3, CIE1, CIE3-4, HT1-3 ]
+    capec: [ 28, 48, 126, 165, 213, 220, 221, 261, 262, 271, 272 ]
+    safecode: [ 3, 16, 24, 35 ]
+  -
+    id: "DV4"
+    value: "4"
+    owasp_scp: [ 8, 10, 183 ]
+    owasp_asvs: [ 4.2.1, 5.1.1, 5.1.2, 11.1.1, 11.1.2 ]
+    owasp_appsensor: [ RE3-6, AE8-11, SE1, SE3-6, IE2-4, HT1-3 ]
+    capec: [ 28, 31, 48, 126, 162, 165, 213, 220, 221, 261 ]
+    safecode: [ 24, 35 ]
+  -
+    id: "DV5"
+    value: "5"
+    owasp_scp: [ 3, 15, 18-22, 168 ]
+    owasp_asvs: [ 1.1.6, 5.3.3, 5.2.1, 5.2.2, 5.2.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 28, 31, 152, 160, 468 ]
+    safecode: [ 2, 17 ]
+  -
+    id: "DV6"
+    value: "6"
+    owasp_scp: [ 3, 168 ]
+    owasp_asvs: [ 1.1.6, 1.5.3, 5.1.3, 13.2.2, 13.2.5 ]
+    owasp_appsensor: [ IE2, IE3 ]
+    capec: [ 28 ]
+    safecode: [ 3, 16, 24 ]
+  -
+    id: "DV7"
+    value: "7"
+    owasp_scp: [ 4, 5, 7, 150 ]
+    owasp_asvs: [ 1.5.3, 13.2.2, 13.2.5 ]
+    owasp_appsensor: [ IE2, IE3, EE1, EE2 ]
+    capec: [ 28, 153, 165 ]
+    safecode: [ 3, 16, 24 ]
+  -
+    id: "DV8"
+    value: "8"
+    owasp_scp: [ 15, 169 ]
+    owasp_asvs: [ 1.1.6, 5.2.2, 5.2.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 28, 31, 152, 160, 468 ]
+    safecode: [ 2, 17 ]
+  -
+    id: "DV9"
+    value: "9"
+    owasp_scp: [ 6, 21, 22, 168 ]
+    owasp_asvs: [ 7.1.3 ]
+    owasp_appsensor: [ IE2, IE3 ]
+    capec: [ 28 ]
+    safecode: [ 3, 16, 24 ]
+  -
+    id: "DVX"
+    value: "10"
+    owasp_scp: [ 2, 19, 92, 95, 180 ]
+    owasp_asvs: [ 1.12.2, 5.1.3, 9.2.3, 12.2.1, 12.3.1-3, 12.4.2, 12.5.2, 14.5.3 ]
+    owasp_appsensor: [ IE4, IE5 ]
+    capec: [ 12, 51, 57, 90, 111, 145, 194, 195, 202, 218, 463 ]
+    safecode: [ 14 ]
+  -
+    id: "DVJ"
+    value: "J"
+    owasp_scp: [ 1, 17 ]
+    owasp_asvs: [ 1.5.3 ]
+    owasp_appsensor: [ RE3, RE4 ]
+    capec: [ 87, 207, 554 ]
+    safecode: [ 2, 17 ]
+  -
+    id: "DVQ"
+    value: "Q"
+    owasp_scp: [ 10, 15, 16, 19, 20 ]
+    owasp_asvs: [ 5.2.1, 5.2.5, 5.3.3, 5.5.4 ]
+    owasp_appsensor: [ IE1, RP3 ]
+    capec: [ 28, 31, 152, 160, 468 ]
+    safecode: [ 2, 17 ]
+  -
+    id: "DVK"
+    value: "K"
+    owasp_scp: [ 15, 19-22, 167, 180, 204, 211, 212 ]
+    owasp_asvs: [ 5.2.1, 5.2.2, 5.3.4, 5.3.7-10 ]
+    owasp_appsensor: [ CIE1, CIE2 ]
+    capec: [ 23, 28, 76, 152, 160, 261 ]
+    safecode: [ 2, 19, 20 ]
+-
+  name: "AUTHENTICATION"
+  cards:
+  -
+    id: "AC2"
+    value: "2"
+    owasp_scp: [ 47, 52 ]
+    owasp_asvs: [ 2.5.2, 7.1.2, 7.1.4, 7.2.1, 8.2.1, 8.2.2, 8.2.3, 8.3.6 ]
+    owasp_appsensor: [ UT1 ]
+    capec: [ ]
+    safecode: [ 28 ]
+  -
+    id: "AC3"
+    value: "3"
+    owasp_scp: [ 36, 37, 40, 43, 48, 51, 119, 139, 140, 146 ]
+    owasp_asvs: [ 2.5.2, 2.5.3 ]
+    owasp_appsensor: [ ]
+    capec: [ 37, 546 ]
+    safecode: [ 28 ]
+  -
+    id: "AC4"
+    value: "4"
+    owasp_scp: [ 33, 53 ]
+    owasp_asvs: [ 2.2.1, 4.1.5 ]
+    owasp_appsensor: [ AE1 ]
+    capec: [ 383 ]
+    safecode: [ 28 ]
+  -
+    id: "AC5"
+    value: "5"
+    owasp_scp: [ 54, 175, 178 ]
+    owasp_asvs: [ 4.1.5 ]
+    owasp_appsensor: [ AE12, HT3 ]
+    capec: [ 70 ]
+    safecode: [ 28 ]
+  -
+    id: "AC6"
+    value: "6"
+    owasp_scp: [ 37, 45, 46, 178 ]
+    owasp_asvs: [ 2.5.6 ]
+    owasp_appsensor: [ ]
+    capec: [ 50 ]
+    safecode: [ 28 ]
+  -
+    id: "AC7"
+    value: "7"
+    owasp_scp: [ 33, 38, 39, 41, 50, 53 ]
+    owasp_asvs: [ 2.1.2, 2.1.7, '2.1.10', 2.2.1 ]
+    owasp_appsensor: [ AE2, AE3 ]
+    capec: [ 2, 16 ]
+    safecode: [ 27 ]
+  -
+    id: "AC8"
+    value: "8"
+    owasp_scp: [ 28 ]
+    owasp_asvs: [ 4.1.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 115 ]
+    safecode: [ 28 ]
+  -
+    id: "AC9"
+    value: "9"
+    owasp_scp: [ 55, 56 ]
+    owasp_asvs: [ 1.4.5, 2.1.6, 2.2.4, 4.1.3, 4.3.3 ]
+    owasp_appsensor: [ ]
+    capec: [ 21 ]
+    safecode: [ 14, 28 ]
+  -
+    id: "ACX"
+    value: "10"
+    owasp_scp: [ 25, 26, 27 ]
+    owasp_asvs: [ 1.1.6, 1.4.4 ]
+    owasp_appsensor: [ ]
+    capec: [ 90, 115 ]
+    safecode: [ 14, 28 ]
+  -
+    id: "ACJ"
+    value: "J"
+    owasp_scp: [ 23, 32, 34 ]
+    owasp_asvs: [ 1.4.5, 4.3.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 115 ]
+    safecode: [ 14, 28 ]
+  -
+    id: "ACQ"
+    value: "Q"
+    owasp_scp: [ 23, 29, 42, 49 ]
+    owasp_asvs: [ 1.4.5, 2.5.6, 2.5.7, 4.3.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 36, 50, 115, 121, 179 ]
+    safecode: [ 14, 28 ]
+  -
+    id: "ACK"
+    value: "K"
+    owasp_scp: [ 24 ]
+    owasp_asvs: [ 4.1.1, 10.2.3, 10.2.4-6 ]
+    owasp_appsensor: [ ]
+    capec: [ 115, 207, 554 ]
+    safecode: [ 14, 28 ]
+-
+  name: "SESSION MANAGEMENT"
+  cards:
+  -
+    id: "SM2"
+    value: "2"
+    owasp_scp: [ 58, 59 ]
+    owasp_asvs: [ 3.7.1 ]
+    owasp_appsensor: [ SE2 ]
+    capec: [ 31, 60, 61 ]
+    safecode: [ 28 ]
+  -
+    id: "SM3"
+    value: "3"
+    owasp_scp: [ 68 ]
+    owasp_asvs: [ 3.3.3, 3.3.4 ]
+    owasp_appsensor: [ ]
+    capec: [ ]
+    safecode: [ 28 ]
+  -
+    id: "SM4"
+    value: "4"
+    owasp_scp: [ 59, 61 ]
+    owasp_asvs: [ 3.4.1-5 ]
+    owasp_appsensor: [ SE2 ]
+    capec: [ 31, 61 ]
+    safecode: [ 28 ]
+  -
+    id: "SM5"
+    value: "5"
+    owasp_scp: [ 60, 62, 66, 67, 71, 72 ]
+    owasp_asvs: [ 3.2.1, 3.2.2, 3.2.4, 3.3.1 ]
+    owasp_appsensor: [ SE4-6 ]
+    capec: [ 31 ]
+    safecode: [ 28 ]
+  -
+    id: "SM6"
+    value: "6"
+    owasp_scp: [ 64, 65 ]
+    owasp_asvs: [ 3.3.2, 3.3.3, 3.3.4 ]
+    owasp_appsensor: [ SE5, SE6 ]
+    capec: [ 21 ]
+    safecode: [ 28 ]
+  -
+    id: "SM7"
+    value: "7"
+    owasp_scp: [ 62, 63 ]
+    owasp_asvs: [ 3.3.1, 3.3.4 ]
+    owasp_appsensor: [ ]
+    capec: [ 21 ]
+    safecode: [ 28 ]
+  -
+    id: "SM8"
+    value: "8"
+    owasp_scp: [ 96 ]
+    owasp_asvs: [ 3.3.2, 3.6.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 21 ]
+    safecode: [ 28 ]
+  -
+    id: "SM9"
+    value: "9"
+    owasp_scp: [ 69, 75, 76, 119, 138 ]
+    owasp_asvs: [ 1.9.1, 3.1.1, 7.1.1, 7.1.2, 7.2.1, 9.1.3, 9.2.2 ]
+    owasp_appsensor: [ SE4-6 ]
+    capec: [ 31, 60 ]
+    safecode: [ 28 ]
+  -
+    id: "SMX"
+    value: "10"
+    owasp_scp: [ 73, 74 ]
+    owasp_asvs: [ 4.2.2 ]
+    owasp_appsensor: [ IE4 ]
+    capec: [ 62, 111 ]
+    safecode: [ 18 ]
+  -
+    id: "SMJ"
+    value: "J"
+    owasp_scp: [ ]
+    owasp_asvs: [ 11.1.1, 11.1.2, 11.1.3 ]
+    owasp_appsensor: [ IE5 ]
+    capec: [ 60 ]
+    safecode: [ 12, 14 ]
+  -
+    id: "SMQ"
+    value: "Q"
+    owasp_scp: [ 58 ]
+    owasp_asvs: [ 1.1.6, 3.7.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 21 ]
+    safecode: [ 14, 28 ]
+  -
+    id: "SMK"
+    value: "K"
+    owasp_scp: [ 58, 60 ]
+    owasp_asvs: [ 1.1.6 ]
+    owasp_appsensor: [ ]
+    capec: [ 21 ]
+    safecode: [ 14, 28 ]
+-
+  name: "AUTHORIZATION"
+  cards:
+  -
+    id: "AZ2"
+    value: "2"
+    owasp_scp: [ 44 ]
+    owasp_asvs: [ 4.1.3, 4.2.1, 5.1.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 153 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZ3"
+    value: "3"
+    owasp_scp: [ 51, 100, 135, 139, 140, 141, 150 ]
+    owasp_asvs: [ 4.1.3, 4.1.5, 8.1.2, 8.2.1, 8.3.1, 8.3.4, 8.3.6, 8.3.8, 12.4.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 69, 213 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZ4"
+    value: "4"
+    owasp_scp: [ 79, 80 ]
+    owasp_asvs: [ 4.1.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 122 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZ5"
+    value: "5"
+    owasp_scp: [ 70, 81, 83, 84, 87-9, 99, 117, 131, 132, 142, 154, 170, 179 ]
+    owasp_asvs: [ 1.2.2, 4.1.1, 4.1.3, 4.2.1 ]
+    owasp_appsensor: [ ACE1, ACE2, ACE3, ACE4, HT2 ]
+    capec: [ 75, 87, 95, 126, 149, 155, 203, 213, 264, 265 ]
+    safecode: [ 8, 10, 11, 13 ]
+  -
+    id: "AZ6"
+    value: "6"
+    owasp_scp: [ 81, 88, 131 ]
+    owasp_asvs: [ 4.1.3, 4.2.1 ]
+    owasp_appsensor: [ ACE1-4 ]
+    capec: [ 122 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZ7"
+    value: "7"
+    owasp_scp: [ 81, 85, 86, 131 ]
+    owasp_asvs: [ 4.1.3, 4.2.1 ]
+    owasp_appsensor: [ ACE1-4 ]
+    capec: [ 122 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZ8"
+    value: "8"
+    owasp_scp: [ 10, 32, 93, 94, 189 ]
+    owasp_asvs: [ 4.1.2, 4.2.1, 4.3.3, 7.3.4, 11.1.1, 11.1.2 ]
+    owasp_appsensor: [ ACE3 ]
+    capec: [ 25, 39, 74, 162, 166, 207 ]
+    safecode: [ 8, 10, 11, 12 ]
+  -
+    id: "AZ9"
+    value: "9"
+    owasp_scp: [ 94 ]
+    owasp_asvs: [ 11.1.3, 11.1.4 ]
+    owasp_appsensor: [ AE3, FIO1-2, UT2-4, STE1-3 ]
+    capec: [ 26, 29, 119, 261 ]
+    safecode: [ 1, 35 ]
+  -
+    id: "AZX"
+    value: "10"
+    owasp_scp: [ 78, 91 ]
+    owasp_asvs: [ 1.1.6, 4.1.1 ]
+    owasp_appsensor: [ ACE1-4 ]
+    capec: [ 36, 95, 121, 179 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZJ"
+    value: "J"
+    owasp_scp: [ 89, 90 ]
+    owasp_asvs: [ 4.1.2, 10.2.3-6 ]
+    owasp_appsensor: [ ]
+    capec: [ 75, 133, 203 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZQ"
+    value: "Q"
+    owasp_scp: [ 209 ]
+    owasp_asvs: [ 5.3.8 ]
+    owasp_appsensor: [ ]
+    capec: [ 17, 30, 69, 234 ]
+    safecode: [ 8, 10, 11 ]
+  -
+    id: "AZK"
+    value: "K"
+    owasp_scp: [ 77, 89, 91 ]
+    owasp_asvs: [ 4.1.1, 4.1.2, 10.2.3-6 ]
+    owasp_appsensor: [ ]
+    capec: [ 207, 554 ]
+    safecode: [ 8, 10, 11 ]
+-
+  name: "CRYPTOGRAPHY"
+  cards:
+  -
+    id: "CR2"
+    value: "2"
+    owasp_scp: [ 105, 133, 135 ]
+    owasp_asvs: [ 6.2.2 ]
+    owasp_appsensor: [ ]
+    capec: [ ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CR3"
+    value: "3"
+    owasp_scp: [ 92, 205, 212 ]
+    owasp_asvs: [ 10.2.3-6, 10.3.1, 10.3.2, 14.1.1, 14.1.4, 14.1.5 ]
+    owasp_appsensor: [ SE1, IE4 ]
+    capec: [ 31, 39, 68, 75, 133, 145, 162, 203, 438, 439, 442 ]
+    safecode: [ 12, 14 ]
+  -
+    id: "CR4"
+    value: "4"
+    owasp_scp: [ 37, 88, 143, 214 ]
+    owasp_asvs: [ 8.3.4, 9.1.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 185, 186, 187 ]
+    safecode: [ 14, 29, 30 ]
+  -
+    id: "CR5"
+    value: "5"
+    owasp_scp: [ 103, 145 ]
+    owasp_asvs: [ 1.9.1, 6.2.1, 9.1.3, 9.2.2 ]
+    owasp_appsensor: [ ]
+    capec: [ ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CR6"
+    value: "6"
+    owasp_scp: [ 36, 37, 143, 146, 147 ]
+    owasp_asvs: [ 1.9.1, 2.2.5, 2.5.1, 8.3.4, 8.3.6, 9.1.3, 9.2.2 ]
+    owasp_appsensor: [ ]
+    capec: [ 31, 57, 102, 157, 158, 384, 466, 546 ]
+    safecode: [ 29 ]
+  -
+    id: "CR7"
+    value: "7"
+    owasp_scp: [ 75, 144, 145, 148 ]
+    owasp_asvs: [ 1.9.2, 6.2.7, 9.1.1, 9.2.1, 9.2.4, 14.4.5 ]
+    owasp_appsensor: [ IE4 ]
+    capec: [ 31, 216 ]
+    safecode: [ 14, 29, 30 ]
+  -
+    id: "CR8"
+    value: "8"
+    owasp_scp: [ 30, 31, 70, 133, 135 ]
+    owasp_asvs: [ 2.4.1, 6.2.2, 6.2.3, 8.3.4 ]
+    owasp_appsensor: [ ]
+    capec: [ 31, 37, 55 ]
+    safecode: [ 21, 29, 31 ]
+  -
+    id: "CR9"
+    value: "9"
+    owasp_scp: [ 60, 104, 105 ]
+    owasp_asvs: [ 6.2.2, 6.2.3, 6.3.1, 6.3.3 ]
+    owasp_appsensor: [ ]
+    capec: [ 97 ]
+    safecode: [ 14, 21, 29, 32, 33 ]
+  -
+    id: "CRX"
+    value: "10"
+    owasp_scp: [ 104, 105 ]
+    owasp_asvs: [ 6.3.3 ]
+    owasp_appsensor: [ ]
+    capec: [ 97, 463 ]
+    safecode: [ 14, 21, 29, 31, 32, 33 ]
+  -
+    id: "CRJ"
+    value: "J"
+    owasp_scp: [ 35, 90, 171, 172 ]
+    owasp_asvs: [ 1.6.1, 1.6.2, 1.6.4, 2.10.4, 6.4.1, 6.4.2 ]
+    owasp_appsensor: [ ]
+    capec: [ 116 ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CRQ"
+    value: "Q"
+    owasp_scp: [ 35, 102 ]
+    owasp_asvs: [ 1.6.1-3, 6.2.3, 8.3.6 ]
+    owasp_appsensor: [ ]
+    capec: [ 116, 117 ]
+    safecode: [ 21, 29 ]
+  -
+    id: "CRK"
+    value: "K"
+    owasp_scp: [ 31, 101 ]
+    owasp_asvs: [ 1.6.2, 6.2.5-8 ]
+    owasp_appsensor: [ ]
+    capec: [ 207, 554 ]
+    safecode: [ 14, 21, 29 ]
+-
+  name: "CORNUCOPIA"
+  cards:
+  -
+    id: "CO2"
+    value: "2"
+    owasp_scp: [ 194-202, 205-209 ]
+    owasp_asvs: [ 14.1.2 ]
+    owasp_appsensor: [ ]
+    capec: [ 25, 26, 29, 96, 123, 124, 128, 129, 264, 265 ]
+    safecode: [ 3, 5, 6, 7, 9, 22, 25, 26, 34 ]
+  -
+    id: "CO3"
+    value: "3"
+    owasp_scp: [ 134 ]
+    owasp_asvs: [ 14.1.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 189, 207 ]
+    safecode: [ ]
+  -
+    id: "CO4"
+    value: "4"
+    owasp_scp: [ 23, 32, 34, 42, 51, 181 ]
+    owasp_asvs: [ 7.2.1, 7.2.2 ]
+    owasp_appsensor: [ ]
+    capec: [ ]
+    safecode: [ ]
+  -
+    id: "CO5"
+    value: "5"
+    owasp_scp: [ ]
+    owasp_asvs: [ 1.9.2, 9.1.1, 5.1.5, 9.2.1, 9.2.4 ]
+    owasp_appsensor: [ ]
+    capec: [ 89, 103, 181, 459 ]
+    safecode: [ ]
+  -
+    id: "CO6"
+    value: "6"
+    owasp_scp: [ 109-112, 155 ]
+    owasp_asvs: [ 4.1.5, 7.1.4 ]
+    owasp_appsensor: [ ]
+    capec: [ 54, 98, 164 ]
+    safecode: [ 4, 11, 23 ]
+  -
+    id: "CO7"
+    value: "7"
+    owasp_scp: [ 113, 114, 115, 117, 118, 121-130 ]
+    owasp_asvs: [ 7.1.2, 7.1.4, 7.2.1, 7.2.2, 7.3.1, 7.3.3, 8.3.5, 9.2.5 ]
+    owasp_appsensor: [ ]
+    capec: [ 93 ]
+    safecode: [ 4 ]
+  -
+    id: "CO8"
+    value: "8"
+    owasp_scp: [ 151, 152, 156, 160, 161, 173-177 ]
+    owasp_asvs: [ 1.4.5, 10.3.1, 10.3.2, 14.1.4, 14.1.5, 14.2.1, 14.2.2 ]
+    owasp_appsensor: [ RE1, RE2 ]
+    capec: [ 37, 220, 310, 436, 536 ]
+    safecode: [ ]
+  -
+    id: "CO9"
+    value: "9"
+    owasp_scp: [ 23, 29, 56, 81, 82, 84-90 ]
+    owasp_asvs: [ 1.4.5, 4.3.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 122, 233 ]
+    safecode: [ ]
+  -
+    id: "COX"
+    value: "10"
+    owasp_scp: [ 57, 151, 152, 204, 205, 213, 214 ]
+    owasp_asvs: [ 1.14.3, 10.1.1, 10.2.3-6, 14.2.1 ]
+    owasp_appsensor: [ ]
+    capec: [ 68, 438, 439, 442, 524, 538 ]
+    safecode: [ 15 ]
+  -
+    id: "COJ"
+    value: "J"
+    owasp_scp: [ 90, 137, 148, 151-154, 175-179, 186, 192 ]
+    owasp_asvs: [ 1.14.3, 14.1.1-5, 14.2.1 ]
+    owasp_appsensor: [ ]
+    capec: [ ]
+    safecode: [ 4 ]
+  -
+    id: "COQ"
+    value: "Q"
+    owasp_scp: [ ]
+    owasp_asvs: [ 8.1.4, 11.1.1-4 ]
+    owasp_appsensor: [ (All) ]
+    capec: [ ]
+    safecode: [ 1, 27 ]
+  -
+    id: "COK"
+    value: "K"
+    owasp_scp: [ 41, 55 ]
+    owasp_asvs: [ 2.2.1, 11.1.3, 11.1.4 ]
+    owasp_appsensor: [ UT1-4, STE3 ]
+    capec: [ 2, 25, 119, 125 ]
+    safecode: [ 1 ]

--- a/priv/repo/migrations/20240509134057_populate_cards.exs
+++ b/priv/repo/migrations/20240509134057_populate_cards.exs
@@ -8,6 +8,5 @@ defmodule Copi.Repo.Migrations.PopulateCards do
     add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/eop-cards--1.0-en.yaml"), nil)
     add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/ecommerce-cards-1.21-en.yaml"), Path.join(:code.priv_dir(:copi), "/repo/cornucopia/ecommerce-mappings-1.2.yaml"))
     add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/masvs-cards-1.00-en.yaml"), Path.join(:code.priv_dir(:copi), "/repo/cornucopia/masvs-mappings-1.0.yaml"))
-    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/masvs-cards-1.00-en.yaml"), Path.join(:code.priv_dir(:copi), "/repo/cornucopia/masvs-mappings-1.0.yaml"))
   end
 end

--- a/priv/repo/migrations/20240515100557_populate_cards_for_webapp_and_mobileapp.exs
+++ b/priv/repo/migrations/20240515100557_populate_cards_for_webapp_and_mobileapp.exs
@@ -1,0 +1,10 @@
+defmodule Copi.Repo.Migrations.PopulateCards do
+  use Ecto.Migration
+
+  import Copi.CardMigration
+
+  def change do
+    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/webapp-cards-2.00-en.yaml"), Path.join(:code.priv_dir(:copi), "/repo/cornucopia/webapp-mappings-2.00.yaml"))
+    add_cards_to_database(Path.join(:code.priv_dir(:copi), "/repo/cornucopia/mobileapp-cards-1.00-en.yaml"), Path.join(:code.priv_dir(:copi), "/repo/cornucopia/mobileapp-mappings-1.00.yaml"))
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -13,7 +13,7 @@
 alias Copi.Repo
 alias Copi.Cornucopia.Card
 
-path = Path.join(File.cwd!(), "priv/repo/cornucopia/ecommerce-cards-1.21-en.yaml")
+path = Path.join(File.cwd!(), "priv/repo/cornucopia/webapp-cards-2.00-en.yaml")
 
 case YamlElixir.read_from_file(path) do
   {:ok, cards} ->
@@ -38,7 +38,7 @@ case YamlElixir.read_from_file(path) do
     end
 end
 
-path = Path.join(File.cwd!(), "priv/repo/cornucopia/ecommerce-mappings-1.2.yaml")
+path = Path.join(File.cwd!(), "priv/repo/cornucopia/webapp-mappings-2.00.yaml")
 
 case YamlElixir.read_from_file(path) do
   {:ok, cards} ->

--- a/test/copi/cornucopia_test.exs
+++ b/test/copi/cornucopia_test.exs
@@ -6,8 +6,8 @@ defmodule Copi.CornucopiaTest do
   describe "games" do
     alias Copi.Cornucopia.Game
 
-    @valid_attrs %{created_at: "2010-04-17T14:00:00Z", edition: "ecommerce", finished_at: "2010-04-17T14:00:00Z", name: "some name", started_at: "2010-04-17T14:00:00Z"}
-    @update_attrs %{created_at: "2011-05-18T15:01:01Z", edition: "ecommerce", finished_at: "2011-05-18T15:01:01Z", name: "some updated name", started_at: "2011-05-18T15:01:01Z"}
+    @valid_attrs %{created_at: "2010-04-17T14:00:00Z", edition: "webapp", finished_at: "2010-04-17T14:00:00Z", name: "some name", started_at: "2010-04-17T14:00:00Z"}
+    @update_attrs %{created_at: "2011-05-18T15:01:01Z", edition: "webapp", finished_at: "2011-05-18T15:01:01Z", name: "some updated name", started_at: "2011-05-18T15:01:01Z"}
     @invalid_attrs %{created_at: nil, finished_at: nil, edition: nil, name: nil, started_at: nil}
 
     def game_fixture(attrs \\ %{}) do
@@ -130,7 +130,7 @@ defmodule Copi.CornucopiaTest do
   describe "cards" do
     alias Copi.Cornucopia.Card
 
-    @valid_attrs %{external_id: "Rsd2", capec: [], category: "some category", description: "some description", edition: "masvs", language: "some language", misc: "some misc", owasp_appsensor: [], owasp_asvs: [], owasp_mastg: ["sadf"], owasp_masvs: [], owasp_scp: [], safecode: [], value: "some value", version: "some version"}
+    @valid_attrs %{external_id: "Rsd2", capec: [], category: "some category", description: "some description", edition: "mobileapp", language: "some language", misc: "some misc", owasp_appsensor: [], owasp_asvs: [], owasp_mastg: ["sadf"], owasp_masvs: [], owasp_scp: [], safecode: [], value: "some value", version: "some version"}
     @update_attrs %{external_id: "R2", capec: [], category: "some updated category", description: "some updated description", edition: "some updated edition", language: "some updated language", misc: "some updated misc", owasp_appsensor: [], owasp_asvs: [], owasp_mastg: [], owasp_masvs: [], owasp_scp: [], safecode: [],  value: "some updated value", version: "some updated version"}
     @invalid_attrs %{external_id: nil, capec: nil, category: nil, description: nil, edition: nil, language: nil, misc: nil, owasp_appsensor: nil, owasp_asvs: nil, owasp_mastg: nil, owasp_masvs: nil, owasp_scp: nil, safecode: nil,  value: nil, version: nil}
 
@@ -158,7 +158,7 @@ defmodule Copi.CornucopiaTest do
       assert card.capec == []
       assert card.category == "some category"
       assert card.description == "some description"
-      assert card.edition == "masvs"
+      assert card.edition == "mobileapp"
       assert card.language == "some language"
       assert card.misc == "some misc"
       assert card.owasp_appsensor == []


### PR DESCRIPTION
@tobyirvine We need to get this one live as well.

It upgrades Cornucopia for web from 1.21 to 2.00.
Instead of ASVS 3.0, you now have ASVS 4.0.
Names used on individual cards has been changed to reflect the current status quo of OWASP.
MASVS edition has been renamed to mobileapp edition and there are probably some changes for the names there too.
